### PR TITLE
[CM-2.1] 약관 동의 UI & 로직 제작

### DIFF
--- a/data/src/main/kotlin/kr/linkerbell/campusmarket/android/data/di/RepositoryModule.kt
+++ b/data/src/main/kotlin/kr/linkerbell/campusmarket/android/data/di/RepositoryModule.kt
@@ -6,9 +6,11 @@ import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import kr.linkerbell.campusmarket.android.data.repository.nonfeature.authentication.RealAuthenticationRepository
 import kr.linkerbell.campusmarket.android.data.repository.nonfeature.authentication.token.RealTokenRepository
+import kr.linkerbell.campusmarket.android.data.repository.nonfeature.term.RealTermRepository
 import kr.linkerbell.campusmarket.android.data.repository.nonfeature.tracking.RealTrackingRepository
 import kr.linkerbell.campusmarket.android.data.repository.nonfeature.user.RealUserRepository
 import kr.linkerbell.campusmarket.android.domain.repository.nonfeature.AuthenticationRepository
+import kr.linkerbell.campusmarket.android.domain.repository.nonfeature.TermRepository
 import kr.linkerbell.campusmarket.android.domain.repository.nonfeature.TokenRepository
 import kr.linkerbell.campusmarket.android.domain.repository.nonfeature.TrackingRepository
 import kr.linkerbell.campusmarket.android.domain.repository.nonfeature.UserRepository
@@ -41,4 +43,10 @@ abstract class RepositoryModule {
     internal abstract fun bindsTrackingRepository(
         userRepository: RealTrackingRepository
     ): TrackingRepository
+
+    @Binds
+    @Singleton
+    internal abstract fun bindsTermRepository(
+        termRepository: RealTermRepository
+    ): TermRepository
 }

--- a/data/src/main/kotlin/kr/linkerbell/campusmarket/android/data/remote/network/api/nonfeature/TermApi.kt
+++ b/data/src/main/kotlin/kr/linkerbell/campusmarket/android/data/remote/network/api/nonfeature/TermApi.kt
@@ -1,0 +1,45 @@
+package kr.linkerbell.campusmarket.android.data.remote.network.api.nonfeature
+
+import io.ktor.client.HttpClient
+import io.ktor.client.request.get
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import kr.linkerbell.campusmarket.android.data.remote.network.di.AuthHttpClient
+import kr.linkerbell.campusmarket.android.data.remote.network.environment.BaseUrlProvider
+import kr.linkerbell.campusmarket.android.data.remote.network.environment.ErrorMessageMapper
+import kr.linkerbell.campusmarket.android.data.remote.network.model.nonfeature.term.AgreeTermListItemReq
+import kr.linkerbell.campusmarket.android.data.remote.network.model.nonfeature.term.AgreeTermListReq
+import kr.linkerbell.campusmarket.android.data.remote.network.model.nonfeature.term.GetTermListRes
+import kr.linkerbell.campusmarket.android.data.remote.network.util.convert
+import javax.inject.Inject
+
+class TermApi @Inject constructor(
+    @AuthHttpClient private val client: HttpClient,
+    private val baseUrlProvider: BaseUrlProvider,
+    private val errorMessageMapper: ErrorMessageMapper
+) {
+    private val baseUrl: String
+        get() = baseUrlProvider.get()
+
+    suspend fun getTermList(): Result<GetTermListRes> {
+        return client.get("$baseUrl/api/v1/terms")
+            .convert(errorMessageMapper::map)
+    }
+
+    suspend fun agreeTermList(
+        termIdList: List<Long>
+    ): Result<Unit> {
+        return client.post("$baseUrl/api/v1/terms/agreement") {
+            setBody(
+                AgreeTermListReq(
+                    terms = termIdList.map {
+                        AgreeTermListItemReq(
+                            id = it,
+                            isAgree = true
+                        )
+                    }
+                )
+            )
+        }.convert(errorMessageMapper::map)
+    }
+}

--- a/data/src/main/kotlin/kr/linkerbell/campusmarket/android/data/remote/network/model/nonfeature/term/AgreeTermListReq.kt
+++ b/data/src/main/kotlin/kr/linkerbell/campusmarket/android/data/remote/network/model/nonfeature/term/AgreeTermListReq.kt
@@ -1,0 +1,18 @@
+package kr.linkerbell.campusmarket.android.data.remote.network.model.nonfeature.term
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class AgreeTermListReq(
+    @SerialName("terms")
+    val terms: List<AgreeTermListItemReq>
+)
+
+@Serializable
+data class AgreeTermListItemReq(
+    @SerialName("termId")
+    val id: Long,
+    @SerialName("isAgree")
+    val isAgree: Boolean
+)

--- a/data/src/main/kotlin/kr/linkerbell/campusmarket/android/data/remote/network/model/nonfeature/term/GetTermListRes.kt
+++ b/data/src/main/kotlin/kr/linkerbell/campusmarket/android/data/remote/network/model/nonfeature/term/GetTermListRes.kt
@@ -1,0 +1,40 @@
+package kr.linkerbell.campusmarket.android.data.remote.network.model.nonfeature.term
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kr.linkerbell.campusmarket.android.data.remote.mapper.DataMapper
+import kr.linkerbell.campusmarket.android.domain.model.nonfeature.term.Term
+
+@Serializable
+data class GetTermListRes(
+    @SerialName("terms")
+    val terms: List<GetTermListItemRes>
+) : DataMapper<List<Term>> {
+    override fun toDomain(): List<Term> {
+        return terms.map { it.toDomain() }
+    }
+}
+
+@Serializable
+data class GetTermListItemRes(
+    @SerialName("id")
+    val id: Long,
+    @SerialName("title")
+    val title: String,
+    @SerialName("url")
+    val url: String,
+    @SerialName("isRequired")
+    val isRequired: Boolean,
+    @SerialName("isAgree")
+    val isAgree: Boolean,
+) : DataMapper<Term> {
+    override fun toDomain(): Term {
+        return Term(
+            id = id,
+            title = title,
+            url = url,
+            isRequired = isRequired,
+            isAgree = isAgree
+        )
+    }
+}

--- a/data/src/main/kotlin/kr/linkerbell/campusmarket/android/data/repository/nonfeature/term/MockTermRepository.kt
+++ b/data/src/main/kotlin/kr/linkerbell/campusmarket/android/data/repository/nonfeature/term/MockTermRepository.kt
@@ -1,0 +1,60 @@
+package kr.linkerbell.campusmarket.android.data.repository.nonfeature.term
+
+import kotlinx.coroutines.delay
+import kr.linkerbell.campusmarket.android.domain.model.nonfeature.term.Term
+import kr.linkerbell.campusmarket.android.domain.repository.nonfeature.TermRepository
+import javax.inject.Inject
+
+class MockTermRepository @Inject constructor() : TermRepository {
+
+    override suspend fun getTermList(): Result<List<Term>> {
+        randomShortDelay()
+        return Result.success(
+            listOf(
+                Term(
+                    id = 0L,
+                    title = "개인정보 수집 이용동의",
+                    url = "https://www.naver.com",
+                    isRequired = true,
+                    isAgree = true
+                ),
+                Term(
+                    id = 1L,
+                    title = "고유식별 정보처리 동의",
+                    url = "https://www.naver.com",
+                    isRequired = true,
+                    isAgree = false
+                ),
+                Term(
+                    id = 2L,
+                    title = "통신사 이용약관 동의",
+                    url = "https://www.naver.com",
+                    isRequired = true,
+                    isAgree = false
+                ),
+                Term(
+                    id = 3L,
+                    title = "서비스 이용약관 동의",
+                    url = "https://www.naver.com",
+                    isRequired = false,
+                    isAgree = false
+                )
+            )
+        )
+    }
+
+    override suspend fun agreeTermList(
+        termIdList: List<Long>
+    ): Result<Unit> {
+        randomShortDelay()
+        return Result.success(Unit)
+    }
+
+    private suspend fun randomShortDelay() {
+        delay(LongRange(100, 500).random())
+    }
+
+    private suspend fun randomLongDelay() {
+        delay(LongRange(500, 2000).random())
+    }
+}

--- a/data/src/main/kotlin/kr/linkerbell/campusmarket/android/data/repository/nonfeature/term/RealTermRepository.kt
+++ b/data/src/main/kotlin/kr/linkerbell/campusmarket/android/data/repository/nonfeature/term/RealTermRepository.kt
@@ -1,0 +1,22 @@
+package kr.linkerbell.campusmarket.android.data.repository.nonfeature.term
+
+import kr.linkerbell.campusmarket.android.data.remote.network.api.nonfeature.TermApi
+import kr.linkerbell.campusmarket.android.data.remote.network.util.toDomain
+import kr.linkerbell.campusmarket.android.domain.model.nonfeature.term.Term
+import kr.linkerbell.campusmarket.android.domain.repository.nonfeature.TermRepository
+import javax.inject.Inject
+
+class RealTermRepository @Inject constructor(
+    private val termApi: TermApi
+) : TermRepository {
+
+    override suspend fun getTermList(): Result<List<Term>> {
+        return termApi.getTermList().toDomain()
+    }
+
+    override suspend fun agreeTermList(
+        termIdList: List<Long>
+    ): Result<Unit> {
+        return termApi.agreeTermList(termIdList)
+    }
+}

--- a/domain/src/main/kotlin/kr/linkerbell/campusmarket/android/domain/model/nonfeature/term/Term.kt
+++ b/domain/src/main/kotlin/kr/linkerbell/campusmarket/android/domain/model/nonfeature/term/Term.kt
@@ -1,0 +1,9 @@
+package kr.linkerbell.campusmarket.android.domain.model.nonfeature.term
+
+data class Term(
+    val id: Long,
+    val title: String,
+    val url: String,
+    val isRequired: Boolean,
+    val isAgree: Boolean,
+)

--- a/domain/src/main/kotlin/kr/linkerbell/campusmarket/android/domain/repository/nonfeature/TermRepository.kt
+++ b/domain/src/main/kotlin/kr/linkerbell/campusmarket/android/domain/repository/nonfeature/TermRepository.kt
@@ -1,0 +1,11 @@
+package kr.linkerbell.campusmarket.android.domain.repository.nonfeature
+
+import kr.linkerbell.campusmarket.android.domain.model.nonfeature.term.Term
+
+interface TermRepository {
+    suspend fun getTermList(): Result<List<Term>>
+
+    suspend fun agreeTermList(
+        termIdList: List<Long>
+    ): Result<Unit>
+}

--- a/domain/src/main/kotlin/kr/linkerbell/campusmarket/android/domain/usecase/nonfeature/term/AgreeTermListUseCase.kt
+++ b/domain/src/main/kotlin/kr/linkerbell/campusmarket/android/domain/usecase/nonfeature/term/AgreeTermListUseCase.kt
@@ -1,0 +1,16 @@
+package kr.linkerbell.campusmarket.android.domain.usecase.nonfeature.term
+
+import kr.linkerbell.campusmarket.android.domain.repository.nonfeature.TermRepository
+import javax.inject.Inject
+
+class AgreeTermListUseCase @Inject constructor(
+    private val termRepository: TermRepository
+) {
+    suspend operator fun invoke(
+        termIdList: List<Long>
+    ): Result<Unit> {
+        return termRepository.agreeTermList(
+            termIdList = termIdList
+        )
+    }
+}

--- a/domain/src/main/kotlin/kr/linkerbell/campusmarket/android/domain/usecase/nonfeature/term/GetTermListUseCase.kt
+++ b/domain/src/main/kotlin/kr/linkerbell/campusmarket/android/domain/usecase/nonfeature/term/GetTermListUseCase.kt
@@ -1,0 +1,13 @@
+package kr.linkerbell.campusmarket.android.domain.usecase.nonfeature.term
+
+import kr.linkerbell.campusmarket.android.domain.model.nonfeature.term.Term
+import kr.linkerbell.campusmarket.android.domain.repository.nonfeature.TermRepository
+import javax.inject.Inject
+
+class GetTermListUseCase @Inject constructor(
+    private val termRepository: TermRepository
+) {
+    suspend operator fun invoke(): Result<List<Term>> {
+        return termRepository.getTermList()
+    }
+}

--- a/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/nonlogin/NonLoginNavGraphNavGraph.kt
+++ b/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/nonlogin/NonLoginNavGraphNavGraph.kt
@@ -3,8 +3,10 @@ package kr.linkerbell.campusmarket.android.presentation.ui.main.nonlogin
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.navigation
+import kr.linkerbell.campusmarket.android.presentation.ui.main.nonlogin.entry.entryDestination
 import kr.linkerbell.campusmarket.android.presentation.ui.main.nonlogin.login.LoginConstant
 import kr.linkerbell.campusmarket.android.presentation.ui.main.nonlogin.login.loginDestination
+import kr.linkerbell.campusmarket.android.presentation.ui.main.nonlogin.register.term.registerTermDestination
 
 fun NavGraphBuilder.nonLoginNavGraphNavGraph(
     navController: NavController
@@ -14,5 +16,7 @@ fun NavGraphBuilder.nonLoginNavGraphNavGraph(
         route = NonLoginConstant.ROUTE
     ) {
         loginDestination(navController = navController)
+        entryDestination(navController = navController)
+        registerTermDestination(navController = navController)
     }
 }

--- a/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/nonlogin/entry/EntryArgument.kt
+++ b/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/nonlogin/entry/EntryArgument.kt
@@ -1,0 +1,30 @@
+package kr.linkerbell.campusmarket.android.presentation.ui.main.nonlogin.entry
+
+import androidx.compose.runtime.Immutable
+import kr.linkerbell.campusmarket.android.common.util.coroutine.event.EventFlow
+import kotlin.coroutines.CoroutineContext
+
+@Immutable
+data class RegisterEntryArgument(
+    val state: RegisterEntryState,
+    val event: EventFlow<RegisterEntryEvent>,
+    val intent: (RegisterEntryIntent) -> Unit,
+    val logEvent: (eventName: String, params: Map<String, Any>) -> Unit,
+    val coroutineContext: CoroutineContext
+)
+
+sealed interface RegisterEntryState {
+    data object Init : RegisterEntryState
+    data object Loading : RegisterEntryState
+}
+
+
+sealed interface RegisterEntryEvent {
+    data object NeedTermAgreement : RegisterEntryEvent
+    data object NeedUniversityRegistration : RegisterEntryEvent
+    data object NeedCampusRegistration : RegisterEntryEvent
+    data object NeedNickname : RegisterEntryEvent
+    data object NoProblem : RegisterEntryEvent
+}
+
+sealed interface RegisterEntryIntent

--- a/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/nonlogin/entry/EntryConstant.kt
+++ b/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/nonlogin/entry/EntryConstant.kt
@@ -1,0 +1,5 @@
+package kr.linkerbell.campusmarket.android.presentation.ui.main.nonlogin.entry
+
+object EntryConstant {
+    const val ROUTE: String = "entry"
+}

--- a/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/nonlogin/entry/EntryDestination.kt
+++ b/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/nonlogin/entry/EntryDestination.kt
@@ -1,0 +1,37 @@
+package kr.linkerbell.campusmarket.android.presentation.ui.main.nonlogin.entry
+
+import androidx.compose.runtime.getValue
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.navigation.NavController
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.compose.composable
+import kr.linkerbell.campusmarket.android.presentation.common.util.compose.ErrorObserver
+
+fun NavGraphBuilder.entryDestination(
+    navController: NavController
+) {
+    composable(
+        route = EntryConstant.ROUTE
+    ) {
+        val viewModel: EntryViewModel = hiltViewModel()
+
+        val argument: RegisterEntryArgument = let {
+            val state by viewModel.state.collectAsStateWithLifecycle()
+
+            RegisterEntryArgument(
+                state = state,
+                event = viewModel.event,
+                intent = viewModel::onIntent,
+                logEvent = viewModel::logEvent,
+                coroutineContext = viewModel.coroutineContext
+            )
+        }
+
+        ErrorObserver(viewModel)
+        RegisterEntryScreen(
+            navController = navController,
+            argument = argument
+        )
+    }
+}

--- a/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/nonlogin/entry/EntryScreen.kt
+++ b/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/nonlogin/entry/EntryScreen.kt
@@ -1,0 +1,106 @@
+package kr.linkerbell.campusmarket.android.presentation.ui.main.nonlogin.entry
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.navigation.NavController
+import androidx.navigation.compose.rememberNavController
+import kotlinx.coroutines.CoroutineExceptionHandler
+import kotlinx.coroutines.plus
+import kr.linkerbell.campusmarket.android.common.util.coroutine.event.MutableEventFlow
+import kr.linkerbell.campusmarket.android.common.util.coroutine.event.eventObserve
+import kr.linkerbell.campusmarket.android.presentation.common.util.compose.LaunchedEffectWithLifecycle
+import kr.linkerbell.campusmarket.android.presentation.ui.main.home.HomeConstant
+import kr.linkerbell.campusmarket.android.presentation.ui.main.nonlogin.register.term.RegisterTermConstant
+
+@Composable
+fun RegisterEntryScreen(
+    navController: NavController,
+    argument: RegisterEntryArgument
+) {
+    val (state, event, intent, logEvent, coroutineContext) = argument
+    val scope = rememberCoroutineScope() + coroutineContext
+    val context = LocalContext.current
+
+    fun navigateToRegisterTerm() {
+        navController.navigate(RegisterTermConstant.ROUTE) {
+            popUpTo(EntryConstant.ROUTE) {
+                inclusive = true
+            }
+        }
+    }
+
+    fun navigateToRegisterUniversity() {
+//        navController.navigate(RegisterUniversityConstant.ROUTE) {
+//            popUpTo(EntryConstant.ROUTE) {
+//                inclusive = true
+//            }
+//        }
+    }
+
+    fun navigateToRegisterCampus() {
+//        navController.navigate(RegisterCampusConstant.ROUTE) {
+//            popUpTo(EntryConstant.ROUTE) {
+//                inclusive = true
+//            }
+//        }
+    }
+
+    fun navigateToRegisterProfile() {
+//        navController.navigate(RegisterProfileConstant.ROUTE) {
+//            popUpTo(EntryConstant.ROUTE) {
+//                inclusive = true
+//            }
+//        }
+    }
+
+    fun navigateToHome() {
+        navController.navigate(HomeConstant.ROUTE) {
+            popUpTo(EntryConstant.ROUTE) {
+                inclusive = true
+            }
+        }
+    }
+
+    LaunchedEffectWithLifecycle(event, coroutineContext) {
+        event.eventObserve { event ->
+            when (event) {
+                RegisterEntryEvent.NeedTermAgreement -> {
+                    navigateToRegisterTerm()
+                }
+
+                RegisterEntryEvent.NeedUniversityRegistration -> {
+                    navigateToRegisterUniversity()
+                }
+
+                RegisterEntryEvent.NeedCampusRegistration -> {
+                    navigateToRegisterCampus()
+                }
+
+                RegisterEntryEvent.NeedNickname -> {
+                    navigateToRegisterProfile()
+                }
+
+                RegisterEntryEvent.NoProblem -> {
+                    navigateToHome()
+                }
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun RegisterEntryScreenPreview() {
+    RegisterEntryScreen(
+        navController = rememberNavController(),
+        argument = RegisterEntryArgument(
+            state = RegisterEntryState.Init,
+            event = MutableEventFlow(),
+            intent = {},
+            logEvent = { _, _ -> },
+            coroutineContext = CoroutineExceptionHandler { _, _ -> }
+        )
+    )
+}

--- a/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/nonlogin/entry/EntryViewModel.kt
+++ b/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/nonlogin/entry/EntryViewModel.kt
@@ -1,0 +1,77 @@
+package kr.linkerbell.campusmarket.android.presentation.ui.main.nonlogin.entry
+
+import androidx.lifecycle.SavedStateHandle
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kr.linkerbell.campusmarket.android.common.util.coroutine.event.EventFlow
+import kr.linkerbell.campusmarket.android.common.util.coroutine.event.MutableEventFlow
+import kr.linkerbell.campusmarket.android.common.util.coroutine.event.asEventFlow
+import kr.linkerbell.campusmarket.android.domain.model.nonfeature.error.ServerException
+import kr.linkerbell.campusmarket.android.domain.usecase.nonfeature.term.GetTermListUseCase
+import kr.linkerbell.campusmarket.android.presentation.common.base.BaseViewModel
+import kr.linkerbell.campusmarket.android.presentation.common.base.ErrorEvent
+import javax.inject.Inject
+
+@HiltViewModel
+class EntryViewModel @Inject constructor(
+    private val savedStateHandle: SavedStateHandle,
+    private val getTermListUseCase: GetTermListUseCase
+) : BaseViewModel() {
+
+    private val _state: MutableStateFlow<RegisterEntryState> =
+        MutableStateFlow(RegisterEntryState.Init)
+    val state: StateFlow<RegisterEntryState> = _state.asStateFlow()
+
+    private val _event: MutableEventFlow<RegisterEntryEvent> = MutableEventFlow()
+    val event: EventFlow<RegisterEntryEvent> = _event.asEventFlow()
+
+    init {
+        launch {
+            checkProgress()
+        }
+    }
+
+    fun onIntent(intent: RegisterEntryIntent) {
+
+    }
+
+    private suspend fun checkProgress() {
+        _state.value = RegisterEntryState.Loading
+
+        getTermListUseCase().onSuccess { termList ->
+            _state.value = RegisterEntryState.Init
+
+//            val isNicknameValid = profile.nickname.isNotEmpty()
+            val isTermAgreed = termList.all { term ->
+                !term.isRequired || term.isAgree
+            }
+
+            when {
+                !isTermAgreed -> {
+                    _event.emit(RegisterEntryEvent.NeedTermAgreement)
+                }
+
+//                !isNicknameValid -> {
+//                    _event.emit(RegisterEntryEvent.NeedNickname)
+//                }
+
+                else -> {
+                    _event.emit(RegisterEntryEvent.NoProblem)
+                }
+            }
+        }.onFailure { exception ->
+            _state.value = RegisterEntryState.Init
+            when (exception) {
+                is ServerException -> {
+                    _errorEvent.emit(ErrorEvent.InvalidRequest(exception))
+                }
+
+                else -> {
+                    _errorEvent.emit(ErrorEvent.UnavailableServer(exception))
+                }
+            }
+        }
+    }
+}

--- a/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/nonlogin/login/LoginScreen.kt
+++ b/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/nonlogin/login/LoginScreen.kt
@@ -45,7 +45,7 @@ import kr.linkerbell.campusmarket.android.presentation.common.view.confirm.Confi
 import kr.linkerbell.campusmarket.android.presentation.common.view.confirm.ConfirmButtonProperties
 import kr.linkerbell.campusmarket.android.presentation.common.view.confirm.ConfirmButtonSize
 import kr.linkerbell.campusmarket.android.presentation.common.view.confirm.ConfirmButtonType
-import kr.linkerbell.campusmarket.android.presentation.ui.main.home.HomeConstant
+import kr.linkerbell.campusmarket.android.presentation.ui.main.nonlogin.entry.EntryConstant
 import timber.log.Timber
 
 @OptIn(ExperimentalFoundationApi::class)
@@ -64,8 +64,8 @@ fun LoginScreen(
     val googleOAuthClientId = stringResource(id = R.string.id_google_oauth_client)
     val isConfirmButtonEnabled = argument.state != LoginState.Loading
 
-    fun navigateToHome() {
-        navController.navigate(HomeConstant.ROUTE) {
+    fun navigateToEntry() {
+        navController.navigate(EntryConstant.ROUTE) {
             popUpTo(LoginConstant.ROUTE) {
                 inclusive = true
             }
@@ -155,7 +155,7 @@ fun LoginScreen(
     fun login(event: LoginEvent.Login) {
         when (event) {
             LoginEvent.Login.Success -> {
-                navigateToHome()
+                navigateToEntry()
             }
         }
     }

--- a/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/nonlogin/register/RegisterConstant.kt
+++ b/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/nonlogin/register/RegisterConstant.kt
@@ -1,0 +1,5 @@
+package kr.linkerbell.campusmarket.android.presentation.ui.main.nonlogin.register
+
+object RegisterConstant {
+    const val ROUTE = "register"
+}

--- a/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/nonlogin/register/term/RegisterTermArgument.kt
+++ b/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/nonlogin/register/term/RegisterTermArgument.kt
@@ -1,0 +1,30 @@
+package kr.linkerbell.campusmarket.android.presentation.ui.main.nonlogin.register.term
+
+import androidx.compose.runtime.Immutable
+import kr.linkerbell.campusmarket.android.common.util.coroutine.event.EventFlow
+import kotlin.coroutines.CoroutineContext
+
+@Immutable
+data class RegisterTermArgument(
+    val state: RegisterTermState,
+    val event: EventFlow<RegisterTermEvent>,
+    val intent: (RegisterTermIntent) -> Unit,
+    val logEvent: (eventName: String, params: Map<String, Any>) -> Unit,
+    val coroutineContext: CoroutineContext
+)
+
+sealed interface RegisterTermState {
+    data object Init : RegisterTermState
+    data object Loading : RegisterTermState
+}
+
+
+sealed interface RegisterTermEvent {
+    sealed interface AgreeTerm : RegisterTermEvent {
+        data object Success : AgreeTerm
+    }
+}
+
+sealed interface RegisterTermIntent {
+    data class OnConfirm(val checkedTermList: List<Long>) : RegisterTermIntent
+}

--- a/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/nonlogin/register/term/RegisterTermConstant.kt
+++ b/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/nonlogin/register/term/RegisterTermConstant.kt
@@ -1,0 +1,7 @@
+package kr.linkerbell.campusmarket.android.presentation.ui.main.nonlogin.register.term
+
+import kr.linkerbell.campusmarket.android.presentation.ui.main.nonlogin.register.RegisterConstant
+
+object RegisterTermConstant {
+    const val ROUTE: String = "${RegisterConstant.ROUTE}/term"
+}

--- a/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/nonlogin/register/term/RegisterTermData.kt
+++ b/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/nonlogin/register/term/RegisterTermData.kt
@@ -1,0 +1,9 @@
+package kr.linkerbell.campusmarket.android.presentation.ui.main.nonlogin.register.term
+
+import androidx.compose.runtime.Immutable
+import kr.linkerbell.campusmarket.android.domain.model.nonfeature.term.Term
+
+@Immutable
+data class RegisterTermData(
+    val termList: List<Term>
+)

--- a/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/nonlogin/register/term/RegisterTermDestination.kt
+++ b/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/nonlogin/register/term/RegisterTermDestination.kt
@@ -1,0 +1,46 @@
+package kr.linkerbell.campusmarket.android.presentation.ui.main.nonlogin.register.term
+
+import androidx.compose.runtime.getValue
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.navigation.NavController
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.compose.composable
+import kr.linkerbell.campusmarket.android.presentation.common.util.compose.ErrorObserver
+
+fun NavGraphBuilder.registerTermDestination(
+    navController: NavController
+) {
+    composable(
+        route = RegisterTermConstant.ROUTE
+    ) {
+        val viewModel: RegisterTermViewModel = hiltViewModel()
+
+        val argument: RegisterTermArgument = let {
+            val state by viewModel.state.collectAsStateWithLifecycle()
+
+            RegisterTermArgument(
+                state = state,
+                event = viewModel.event,
+                intent = viewModel::onIntent,
+                logEvent = viewModel::logEvent,
+                coroutineContext = viewModel.coroutineContext
+            )
+        }
+
+        val data: RegisterTermData = let {
+            val termList by viewModel.termList.collectAsStateWithLifecycle()
+
+            RegisterTermData(
+                termList = termList
+            )
+        }
+
+        ErrorObserver(viewModel)
+        RegisterTermScreen(
+            navController = navController,
+            argument = argument,
+            data = data
+        )
+    }
+}

--- a/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/nonlogin/register/term/RegisterTermScreen.kt
+++ b/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/nonlogin/register/term/RegisterTermScreen.kt
@@ -1,0 +1,269 @@
+package kr.linkerbell.campusmarket.android.presentation.ui.main.nonlogin.register.term
+
+import android.content.Intent
+import android.net.Uri
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.core.content.ContextCompat
+import androidx.navigation.NavController
+import androidx.navigation.compose.rememberNavController
+import com.google.firebase.crashlytics.ktx.crashlytics
+import com.google.firebase.ktx.Firebase
+import kotlinx.coroutines.CoroutineExceptionHandler
+import kotlinx.coroutines.plus
+import kr.linkerbell.campusmarket.android.common.util.coroutine.event.MutableEventFlow
+import kr.linkerbell.campusmarket.android.common.util.coroutine.event.eventObserve
+import kr.linkerbell.campusmarket.android.domain.model.nonfeature.term.Term
+import kr.linkerbell.campusmarket.android.presentation.R
+import kr.linkerbell.campusmarket.android.presentation.common.theme.Blue700
+import kr.linkerbell.campusmarket.android.presentation.common.theme.Body1
+import kr.linkerbell.campusmarket.android.presentation.common.theme.Gray400
+import kr.linkerbell.campusmarket.android.presentation.common.theme.Gray900
+import kr.linkerbell.campusmarket.android.presentation.common.theme.Headline0
+import kr.linkerbell.campusmarket.android.presentation.common.theme.Headline2
+import kr.linkerbell.campusmarket.android.presentation.common.theme.Space12
+import kr.linkerbell.campusmarket.android.presentation.common.theme.Space20
+import kr.linkerbell.campusmarket.android.presentation.common.theme.Space24
+import kr.linkerbell.campusmarket.android.presentation.common.theme.Space32
+import kr.linkerbell.campusmarket.android.presentation.common.theme.Space80
+import kr.linkerbell.campusmarket.android.presentation.common.theme.White
+import kr.linkerbell.campusmarket.android.presentation.common.util.compose.LaunchedEffectWithLifecycle
+import kr.linkerbell.campusmarket.android.presentation.common.util.compose.safeNavigate
+import kr.linkerbell.campusmarket.android.presentation.common.view.RippleBox
+import kr.linkerbell.campusmarket.android.presentation.common.view.confirm.ConfirmButton
+import kr.linkerbell.campusmarket.android.presentation.common.view.confirm.ConfirmButtonProperties
+import kr.linkerbell.campusmarket.android.presentation.common.view.confirm.ConfirmButtonSize
+import kr.linkerbell.campusmarket.android.presentation.common.view.confirm.ConfirmButtonType
+import kr.linkerbell.campusmarket.android.presentation.ui.main.nonlogin.entry.EntryConstant
+import timber.log.Timber
+
+@Composable
+fun RegisterTermScreen(
+    navController: NavController,
+    argument: RegisterTermArgument,
+    data: RegisterTermData
+) {
+    val (state, event, intent, logEvent, coroutineContext) = argument
+    val scope = rememberCoroutineScope() + coroutineContext
+
+    val checkedTermList = remember { mutableStateListOf<Long>() }
+
+    val isNecessaryTermChecked = data.termList.all { term ->
+        !term.isRequired || checkedTermList.contains(term.id)
+    }
+    val isConfirmButtonEnabled = state != RegisterTermState.Loading && isNecessaryTermChecked
+
+    fun navigateToEntry() {
+        navController.safeNavigate(EntryConstant.ROUTE) {
+            popUpTo(RegisterTermConstant.ROUTE) {
+                inclusive = true
+            }
+        }
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(White)
+            .verticalScroll(rememberScrollState()),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Spacer(modifier = Modifier.height(100.dp))
+        Text(
+            text = "서비스 약관동의",
+            style = Headline0.merge(Gray900)
+        )
+        Spacer(modifier = Modifier.height(Space12))
+        Text(
+            text = "서비스 이용 동의가 필요해요",
+            style = Headline2.merge(Gray900)
+        )
+        Spacer(modifier = Modifier.height(Space80))
+        data.termList.forEach { term ->
+            RegisterTermScreenItem(
+                term = term,
+                isChecked = checkedTermList.contains(term.id),
+                onCheckedChange = { isChecked ->
+                    if (isChecked) {
+                        checkedTermList.add(term.id)
+                    } else {
+                        checkedTermList.remove(term.id)
+                    }
+                }
+            )
+        }
+        Spacer(modifier = Modifier.height(Space80))
+        ConfirmButton(
+            modifier = Modifier
+                .padding(start = Space20, end = Space20, bottom = Space12)
+                .fillMaxWidth(),
+            properties = ConfirmButtonProperties(
+                size = ConfirmButtonSize.Large,
+                type = ConfirmButtonType.Primary
+            ),
+            isEnabled = isConfirmButtonEnabled,
+            onClick = {
+                intent(RegisterTermIntent.OnConfirm(checkedTermList))
+            }
+        ) { style ->
+            Text(
+                text = "다음",
+                style = style
+            )
+        }
+    }
+
+    fun patchTerm(event: RegisterTermEvent.AgreeTerm) {
+        when (event) {
+            RegisterTermEvent.AgreeTerm.Success -> {
+                navigateToEntry()
+            }
+        }
+    }
+
+    LaunchedEffectWithLifecycle(event, coroutineContext) {
+        event.eventObserve { event ->
+            when (event) {
+                is RegisterTermEvent.AgreeTerm -> {
+                    patchTerm(event)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun RegisterTermScreenItem(
+    term: Term,
+    isChecked: Boolean,
+    onCheckedChange: (Boolean) -> Unit
+) {
+    val context = LocalContext.current
+
+    val text = if (term.isRequired) {
+        "[필수] ${term.title}"
+    } else {
+        "[선택] ${term.title}"
+    }
+
+    fun navigateToTermLink() {
+        runCatching {
+            val link = Uri.parse(term.url)
+            val browserIntent = Intent(Intent.ACTION_VIEW, link)
+            ContextCompat.startActivity(context, browserIntent, null)
+        }.onFailure { exception ->
+            Timber.d(exception)
+            Firebase.crashlytics.recordException(exception)
+        }
+    }
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = Space32, vertical = Space12),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        if (term.url.isEmpty()) {
+            Text(
+                text = text,
+                style = Body1.merge(
+                    color = Gray900
+                )
+            )
+        } else {
+            Text(
+                modifier = Modifier.clickable {
+                    navigateToTermLink()
+                },
+                text = text,
+                style = Body1.merge(
+                    color = Gray900,
+                    textDecoration = TextDecoration.Underline
+                )
+            )
+        }
+        Spacer(modifier = Modifier.weight(1f))
+        RippleBox(
+            onClick = {
+                onCheckedChange(!isChecked)
+            }
+        ) {
+            Icon(
+                modifier = Modifier.size(Space24),
+                painter = painterResource(id = R.drawable.ic_check_box_checked),
+                contentDescription = null,
+                tint = if (isChecked) Blue700 else Gray400
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun RegisterTermScreenPreview() {
+    RegisterTermScreen(
+        navController = rememberNavController(),
+        argument = RegisterTermArgument(
+            state = RegisterTermState.Init,
+            event = MutableEventFlow(),
+            intent = {},
+            logEvent = { _, _ -> },
+            coroutineContext = CoroutineExceptionHandler { _, _ -> }
+        ),
+        data = RegisterTermData(
+            termList = listOf(
+                Term(
+                    id = 0L,
+                    title = "개인정보 수집 이용동의",
+                    url = "https://www.naver.com",
+                    isRequired = true,
+                    isAgree = true
+                ),
+                Term(
+                    id = 1L,
+                    title = "고유식별 정보처리 동의",
+                    url = "https://www.naver.com",
+                    isRequired = true,
+                    isAgree = false
+                ),
+                Term(
+                    id = 2L,
+                    title = "통신사 이용약관 동의",
+                    url = "https://www.naver.com",
+                    isRequired = true,
+                    isAgree = false
+                ),
+                Term(
+                    id = 3L,
+                    title = "서비스 이용약관 동의",
+                    url = "https://www.naver.com",
+                    isRequired = false,
+                    isAgree = false
+                )
+            )
+        )
+    )
+}

--- a/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/nonlogin/register/term/RegisterTermViewModel.kt
+++ b/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/nonlogin/register/term/RegisterTermViewModel.kt
@@ -1,0 +1,93 @@
+package kr.linkerbell.campusmarket.android.presentation.ui.main.nonlogin.register.term
+
+import androidx.lifecycle.SavedStateHandle
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kr.linkerbell.campusmarket.android.common.util.coroutine.event.EventFlow
+import kr.linkerbell.campusmarket.android.common.util.coroutine.event.MutableEventFlow
+import kr.linkerbell.campusmarket.android.common.util.coroutine.event.asEventFlow
+import kr.linkerbell.campusmarket.android.domain.model.nonfeature.error.ServerException
+import kr.linkerbell.campusmarket.android.domain.model.nonfeature.term.Term
+import kr.linkerbell.campusmarket.android.domain.usecase.nonfeature.term.AgreeTermListUseCase
+import kr.linkerbell.campusmarket.android.domain.usecase.nonfeature.term.GetTermListUseCase
+import kr.linkerbell.campusmarket.android.presentation.common.base.BaseViewModel
+import kr.linkerbell.campusmarket.android.presentation.common.base.ErrorEvent
+import javax.inject.Inject
+
+@HiltViewModel
+class RegisterTermViewModel @Inject constructor(
+    private val savedStateHandle: SavedStateHandle,
+    private val getTermListUseCase: GetTermListUseCase,
+    private val agreeTermListUseCase: AgreeTermListUseCase
+) : BaseViewModel() {
+
+    private val _state: MutableStateFlow<RegisterTermState> =
+        MutableStateFlow(RegisterTermState.Init)
+    val state: StateFlow<RegisterTermState> = _state.asStateFlow()
+
+    private val _event: MutableEventFlow<RegisterTermEvent> = MutableEventFlow()
+    val event: EventFlow<RegisterTermEvent> = _event.asEventFlow()
+
+    private val _termList: MutableStateFlow<List<Term>> = MutableStateFlow(emptyList())
+    val termList: StateFlow<List<Term>> = _termList.asStateFlow()
+
+    init {
+        launch {
+            getTermList()
+        }
+    }
+
+    fun onIntent(intent: RegisterTermIntent) {
+        when (intent) {
+            is RegisterTermIntent.OnConfirm -> {
+                agreeTermState(intent.checkedTermList)
+            }
+        }
+    }
+
+    private suspend fun getTermList() {
+        getTermListUseCase().onSuccess { termList ->
+            _termList.value = termList.filter { term ->
+                !term.isAgree
+            }
+        }.onFailure { exception ->
+            _state.value = RegisterTermState.Init
+            when (exception) {
+                is ServerException -> {
+                    _errorEvent.emit(ErrorEvent.InvalidRequest(exception))
+                }
+
+                else -> {
+                    _errorEvent.emit(ErrorEvent.UnavailableServer(exception))
+                }
+            }
+        }
+    }
+
+    private fun agreeTermState(
+        checkedTermList: List<Long>
+    ) {
+        launch {
+            _state.value = RegisterTermState.Loading
+            agreeTermListUseCase(
+                termIdList = checkedTermList
+            ).onSuccess {
+                _event.emit(RegisterTermEvent.AgreeTerm.Success)
+                _state.value = RegisterTermState.Init
+            }.onFailure { exception ->
+                _state.value = RegisterTermState.Init
+                when (exception) {
+                    is ServerException -> {
+                        _errorEvent.emit(ErrorEvent.InvalidRequest(exception))
+                    }
+
+                    else -> {
+                        _errorEvent.emit(ErrorEvent.UnavailableServer(exception))
+                    }
+                }
+            }
+        }
+    }
+}

--- a/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/splash/SplashScreen.kt
+++ b/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/splash/SplashScreen.kt
@@ -16,15 +16,15 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import androidx.navigation.compose.rememberNavController
+import kotlinx.coroutines.CoroutineExceptionHandler
+import kotlinx.coroutines.plus
 import kr.linkerbell.campusmarket.android.common.util.coroutine.event.MutableEventFlow
 import kr.linkerbell.campusmarket.android.common.util.coroutine.event.eventObserve
 import kr.linkerbell.campusmarket.android.presentation.R
 import kr.linkerbell.campusmarket.android.presentation.common.theme.Headline1
 import kr.linkerbell.campusmarket.android.presentation.common.util.compose.LaunchedEffectWithLifecycle
-import kr.linkerbell.campusmarket.android.presentation.ui.main.home.HomeConstant
 import kr.linkerbell.campusmarket.android.presentation.ui.main.nonlogin.NonLoginConstant
-import kotlinx.coroutines.CoroutineExceptionHandler
-import kotlinx.coroutines.plus
+import kr.linkerbell.campusmarket.android.presentation.ui.main.nonlogin.entry.EntryConstant
 
 @Composable
 fun SplashScreen(
@@ -34,8 +34,8 @@ fun SplashScreen(
     val (state, event, intent, logEvent, coroutineContext) = argument
     val scope = rememberCoroutineScope() + coroutineContext
 
-    fun navigateToHome() {
-        navController.navigate(HomeConstant.ROUTE) {
+    fun navigateToEntry() {
+        navController.navigate(EntryConstant.ROUTE) {
             popUpTo(SplashConstant.ROUTE) {
                 inclusive = true
             }
@@ -53,7 +53,7 @@ fun SplashScreen(
     fun login(event: SplashEvent.Login) {
         when (event) {
             is SplashEvent.Login.Success -> {
-                navigateToHome()
+                navigateToEntry()
             }
 
             is SplashEvent.Login.Fail -> {


### PR DESCRIPTION
## **설명**
- 약관 동의 관련 API, Repository, UseCase 추가
- 약관 동의 화면 UI / 로직 제작
- 약관 동의 화면 이동 여부 체크 화면 (Entry) 추가

## 참고
- 실제 테스트가 불가능해, 임의로 모킹 데이터로 테스트 완료 했습니다.
![image](https://github.com/user-attachments/assets/095b7c17-68f3-400e-a5b2-fc05bf087d10)

## 체크리스트
- [x] : 빌드 테스트를 진행하셨나요?
- [x] : 실제 기기에서 테스트를 진행하셨나요?
