### PR TITLE
[CM-3.1] 학교 이메일 인증에 필요한 화면 UI & 로직 제작

### DIFF
--- a/data/src/main/kotlin/kr/linkerbell/campusmarket/android/data/remote/network/api/nonfeature/AuthenticationApi.kt
+++ b/data/src/main/kotlin/kr/linkerbell/campusmarket/android/data/remote/network/api/nonfeature/AuthenticationApi.kt
@@ -3,9 +3,13 @@ package kr.linkerbell.campusmarket.android.data.remote.network.api.nonfeature
 import io.ktor.client.HttpClient
 import io.ktor.client.request.patch
 import io.ktor.client.request.post
+import io.ktor.client.request.setBody
 import kr.linkerbell.campusmarket.android.data.remote.network.di.AuthHttpClient
 import kr.linkerbell.campusmarket.android.data.remote.network.environment.BaseUrlProvider
 import kr.linkerbell.campusmarket.android.data.remote.network.environment.ErrorMessageMapper
+import kr.linkerbell.campusmarket.android.data.remote.network.model.nonfeature.authentication.SendEmailVerifyCodeReq
+import kr.linkerbell.campusmarket.android.data.remote.network.model.nonfeature.authentication.SendEmailVerifyCodeRes
+import kr.linkerbell.campusmarket.android.data.remote.network.model.nonfeature.authentication.VerifyEmailVerifyCodeReq
 import kr.linkerbell.campusmarket.android.data.remote.network.util.convert
 import javax.inject.Inject
 
@@ -16,6 +20,32 @@ class AuthenticationApi @Inject constructor(
 ) {
     private val baseUrl: String
         get() = baseUrlProvider.get()
+
+    suspend fun sendEmailVerifyCode(
+        email: String
+    ): Result<SendEmailVerifyCodeRes> {
+        return client.post("$baseUrl/api/v1/auth/emails/send") {
+            setBody(
+                SendEmailVerifyCodeReq(
+                    email = email
+                )
+            )
+        }.convert(errorMessageMapper::map)
+    }
+
+    suspend fun verifyEmailVerifyCode(
+        token: String,
+        verifyCode: String
+    ): Result<Unit> {
+        return client.post("$baseUrl/api/v1/auth/emails/verify") {
+            setBody(
+                VerifyEmailVerifyCodeReq(
+                    token = token,
+                    verifyCode = verifyCode
+                )
+            )
+        }.convert(errorMessageMapper::map)
+    }
 
     suspend fun logout(): Result<Unit> {
         return client.post("$baseUrl/api/v1/auth/logout")

--- a/data/src/main/kotlin/kr/linkerbell/campusmarket/android/data/remote/network/model/nonfeature/authentication/SendEmailVerifyCodeReq.kt
+++ b/data/src/main/kotlin/kr/linkerbell/campusmarket/android/data/remote/network/model/nonfeature/authentication/SendEmailVerifyCodeReq.kt
@@ -1,0 +1,10 @@
+package kr.linkerbell.campusmarket.android.data.remote.network.model.nonfeature.authentication
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class SendEmailVerifyCodeReq(
+    @SerialName("email")
+    val email: String
+)

--- a/data/src/main/kotlin/kr/linkerbell/campusmarket/android/data/remote/network/model/nonfeature/authentication/SendEmailVerifyCodeRes.kt
+++ b/data/src/main/kotlin/kr/linkerbell/campusmarket/android/data/remote/network/model/nonfeature/authentication/SendEmailVerifyCodeRes.kt
@@ -1,0 +1,15 @@
+package kr.linkerbell.campusmarket.android.data.remote.network.model.nonfeature.authentication
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kr.linkerbell.campusmarket.android.data.remote.mapper.DataMapper
+
+@Serializable
+data class SendEmailVerifyCodeRes(
+    @SerialName("token")
+    val token: String
+) : DataMapper<String> {
+    override fun toDomain(): String {
+        return token
+    }
+}

--- a/data/src/main/kotlin/kr/linkerbell/campusmarket/android/data/remote/network/model/nonfeature/authentication/VerifyEmailVerifyCodeReq.kt
+++ b/data/src/main/kotlin/kr/linkerbell/campusmarket/android/data/remote/network/model/nonfeature/authentication/VerifyEmailVerifyCodeReq.kt
@@ -1,0 +1,12 @@
+package kr.linkerbell.campusmarket.android.data.remote.network.model.nonfeature.authentication
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class VerifyEmailVerifyCodeReq(
+    @SerialName("token")
+    val token: String,
+    @SerialName("verifyCode")
+    val verifyCode: String
+)

--- a/data/src/main/kotlin/kr/linkerbell/campusmarket/android/data/repository/nonfeature/authentication/MockAuthenticationRepository.kt
+++ b/data/src/main/kotlin/kr/linkerbell/campusmarket/android/data/repository/nonfeature/authentication/MockAuthenticationRepository.kt
@@ -1,14 +1,29 @@
 package kr.linkerbell.campusmarket.android.data.repository.nonfeature.authentication
 
+import kotlinx.coroutines.delay
 import kr.linkerbell.campusmarket.android.domain.model.nonfeature.error.ServerException
 import kr.linkerbell.campusmarket.android.domain.repository.nonfeature.AuthenticationRepository
 import kr.linkerbell.campusmarket.android.domain.repository.nonfeature.TokenRepository
 import javax.inject.Inject
-import kotlinx.coroutines.delay
 
 class MockAuthenticationRepository @Inject constructor(
     private val tokenRepository: TokenRepository
 ) : AuthenticationRepository {
+
+    override suspend fun sendEmailVerifyCode(
+        email: String
+    ): Result<String> {
+        randomShortDelay()
+        return Result.success("MOCK_VERIFY_CODE")
+    }
+
+    override suspend fun verifyEmailVerifyCode(
+        token: String,
+        verifyCode: String
+    ): Result<Unit> {
+        randomShortDelay()
+        return Result.success(Unit)
+    }
 
     override suspend fun logout(): Result<Unit> {
         randomShortDelay()

--- a/data/src/main/kotlin/kr/linkerbell/campusmarket/android/data/repository/nonfeature/authentication/RealAuthenticationRepository.kt
+++ b/data/src/main/kotlin/kr/linkerbell/campusmarket/android/data/repository/nonfeature/authentication/RealAuthenticationRepository.kt
@@ -1,6 +1,7 @@
 package kr.linkerbell.campusmarket.android.data.repository.nonfeature.authentication
 
 import kr.linkerbell.campusmarket.android.data.remote.network.api.nonfeature.AuthenticationApi
+import kr.linkerbell.campusmarket.android.data.remote.network.util.toDomain
 import kr.linkerbell.campusmarket.android.domain.repository.nonfeature.AuthenticationRepository
 import kr.linkerbell.campusmarket.android.domain.repository.nonfeature.TokenRepository
 import javax.inject.Inject
@@ -9,6 +10,24 @@ class RealAuthenticationRepository @Inject constructor(
     private val authenticationApi: AuthenticationApi,
     private val tokenRepository: TokenRepository
 ) : AuthenticationRepository {
+
+    override suspend fun sendEmailVerifyCode(
+        email: String
+    ): Result<String> {
+        return authenticationApi.sendEmailVerifyCode(
+            email = email
+        ).toDomain()
+    }
+
+    override suspend fun verifyEmailVerifyCode(
+        token: String,
+        verifyCode: String
+    ): Result<Unit> {
+        return authenticationApi.verifyEmailVerifyCode(
+            token = token,
+            verifyCode = verifyCode
+        )
+    }
 
     override suspend fun logout(): Result<Unit> {
         return authenticationApi.logout()

--- a/domain/src/main/kotlin/kr/linkerbell/campusmarket/android/domain/repository/nonfeature/AuthenticationRepository.kt
+++ b/domain/src/main/kotlin/kr/linkerbell/campusmarket/android/domain/repository/nonfeature/AuthenticationRepository.kt
@@ -2,6 +2,15 @@ package kr.linkerbell.campusmarket.android.domain.repository.nonfeature
 
 interface AuthenticationRepository {
 
+    suspend fun sendEmailVerifyCode(
+        email: String
+    ): Result<String>
+
+    suspend fun verifyEmailVerifyCode(
+        token: String,
+        verifyCode: String
+    ): Result<Unit>
+
     suspend fun logout(): Result<Unit>
 
     suspend fun withdraw(): Result<Unit>

--- a/domain/src/main/kotlin/kr/linkerbell/campusmarket/android/domain/usecase/nonfeature/authentication/SendEmailVerifyCodeUseCase.kt
+++ b/domain/src/main/kotlin/kr/linkerbell/campusmarket/android/domain/usecase/nonfeature/authentication/SendEmailVerifyCodeUseCase.kt
@@ -1,0 +1,16 @@
+package kr.linkerbell.campusmarket.android.domain.usecase.nonfeature.authentication
+
+import kr.linkerbell.campusmarket.android.domain.repository.nonfeature.AuthenticationRepository
+import javax.inject.Inject
+
+class SendEmailVerifyCodeUseCase @Inject constructor(
+    private val authenticationRepository: AuthenticationRepository
+) {
+    suspend operator fun invoke(
+        email: String
+    ): Result<String> {
+        return authenticationRepository.sendEmailVerifyCode(
+            email = email
+        )
+    }
+}

--- a/domain/src/main/kotlin/kr/linkerbell/campusmarket/android/domain/usecase/nonfeature/authentication/VerifyEmailVerifyCodeUseCase.kt
+++ b/domain/src/main/kotlin/kr/linkerbell/campusmarket/android/domain/usecase/nonfeature/authentication/VerifyEmailVerifyCodeUseCase.kt
@@ -1,0 +1,18 @@
+package kr.linkerbell.campusmarket.android.domain.usecase.nonfeature.authentication
+
+import kr.linkerbell.campusmarket.android.domain.repository.nonfeature.AuthenticationRepository
+import javax.inject.Inject
+
+class VerifyEmailVerifyCodeUseCase @Inject constructor(
+    private val authenticationRepository: AuthenticationRepository
+) {
+    suspend operator fun invoke(
+        token: String,
+        verifyCode: String
+    ): Result<Unit> {
+        return authenticationRepository.verifyEmailVerifyCode(
+            token = token,
+            verifyCode = verifyCode
+        )
+    }
+}

--- a/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/common/view/textfield/TypingTextField.kt
+++ b/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/common/view/textfield/TypingTextField.kt
@@ -122,7 +122,7 @@ fun TypingTextField(
                     placeholder = {
                         Text(
                             text = hintText,
-                            style = Body1.merge(Gray900)
+                            style = Body1.merge(Gray400)
                         )
                     },
                     contentPadding = PaddingValues(0.dp),

--- a/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/nonlogin/NonLoginNavGraphNavGraph.kt
+++ b/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/nonlogin/NonLoginNavGraphNavGraph.kt
@@ -8,6 +8,7 @@ import kr.linkerbell.campusmarket.android.presentation.ui.main.nonlogin.login.Lo
 import kr.linkerbell.campusmarket.android.presentation.ui.main.nonlogin.login.loginDestination
 import kr.linkerbell.campusmarket.android.presentation.ui.main.nonlogin.register.profile.registerProfileDestination
 import kr.linkerbell.campusmarket.android.presentation.ui.main.nonlogin.register.term.registerTermDestination
+import kr.linkerbell.campusmarket.android.presentation.ui.main.nonlogin.register.university.registerUniversityDestination
 
 fun NavGraphBuilder.nonLoginNavGraphNavGraph(
     navController: NavController
@@ -20,5 +21,6 @@ fun NavGraphBuilder.nonLoginNavGraphNavGraph(
         entryDestination(navController = navController)
         registerTermDestination(navController = navController)
         registerProfileDestination(navController = navController)
+        registerUniversityDestination(navController = navController)
     }
 }

--- a/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/nonlogin/entry/EntryArgument.kt
+++ b/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/nonlogin/entry/EntryArgument.kt
@@ -18,7 +18,6 @@ sealed interface RegisterEntryState {
     data object Loading : RegisterEntryState
 }
 
-
 sealed interface RegisterEntryEvent {
     data object NeedTermAgreement : RegisterEntryEvent
     data object NeedUniversityRegistration : RegisterEntryEvent

--- a/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/nonlogin/entry/EntryScreen.kt
+++ b/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/nonlogin/entry/EntryScreen.kt
@@ -14,6 +14,7 @@ import kr.linkerbell.campusmarket.android.presentation.common.util.compose.Launc
 import kr.linkerbell.campusmarket.android.presentation.ui.main.home.HomeConstant
 import kr.linkerbell.campusmarket.android.presentation.ui.main.nonlogin.register.profile.RegisterProfileConstant
 import kr.linkerbell.campusmarket.android.presentation.ui.main.nonlogin.register.term.RegisterTermConstant
+import kr.linkerbell.campusmarket.android.presentation.ui.main.nonlogin.register.university.RegisterUniversityConstant
 
 @Composable
 fun RegisterEntryScreen(
@@ -33,11 +34,11 @@ fun RegisterEntryScreen(
     }
 
     fun navigateToRegisterUniversity() {
-//        navController.navigate(RegisterUniversityConstant.ROUTE) {
-//            popUpTo(EntryConstant.ROUTE) {
-//                inclusive = true
-//            }
-//        }
+        navController.navigate(RegisterUniversityConstant.ROUTE) {
+            popUpTo(EntryConstant.ROUTE) {
+                inclusive = true
+            }
+        }
     }
 
     fun navigateToRegisterCampus() {

--- a/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/nonlogin/entry/EntryViewModel.kt
+++ b/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/nonlogin/entry/EntryViewModel.kt
@@ -50,6 +50,8 @@ class EntryViewModel @Inject constructor(
             _state.value = RegisterEntryState.Init
 
             val isNicknameValid = profile.nickname.isNotEmpty()
+            val isUniversityValid = profile.schoolEmail.isNotEmpty()
+            val isCampusValid = profile.campusId != -1L
             val isTermAgreed = termList.all { term ->
                 !term.isRequired || term.isAgree
             }
@@ -57,6 +59,14 @@ class EntryViewModel @Inject constructor(
             when {
                 !isTermAgreed -> {
                     _event.emit(RegisterEntryEvent.NeedTermAgreement)
+                }
+
+                !isUniversityValid -> {
+                    _event.emit(RegisterEntryEvent.NeedUniversityRegistration)
+                }
+
+                !isCampusValid -> {
+                    _event.emit(RegisterEntryEvent.NeedCampusRegistration)
                 }
 
                 !isNicknameValid -> {

--- a/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/nonlogin/login/LoginArgument.kt
+++ b/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/nonlogin/login/LoginArgument.kt
@@ -18,7 +18,6 @@ sealed interface LoginState {
     data object Loading : LoginState
 }
 
-
 sealed interface LoginEvent {
     sealed interface Login : LoginEvent {
         data object Success : Login

--- a/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/nonlogin/register/profile/RegisterProfileArgument.kt
+++ b/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/nonlogin/register/profile/RegisterProfileArgument.kt
@@ -19,7 +19,6 @@ sealed interface RegisterProfileState {
     data object Loading : RegisterProfileState
 }
 
-
 sealed interface RegisterProfileEvent {
     sealed interface CheckNickname : RegisterProfileEvent {
         data object Failure : CheckNickname

--- a/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/nonlogin/register/term/RegisterTermArgument.kt
+++ b/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/nonlogin/register/term/RegisterTermArgument.kt
@@ -18,7 +18,6 @@ sealed interface RegisterTermState {
     data object Loading : RegisterTermState
 }
 
-
 sealed interface RegisterTermEvent {
     sealed interface AgreeTerm : RegisterTermEvent {
         data object Success : AgreeTerm

--- a/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/nonlogin/register/university/RegisterUniversityArgument.kt
+++ b/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/nonlogin/register/university/RegisterUniversityArgument.kt
@@ -1,0 +1,36 @@
+package kr.linkerbell.campusmarket.android.presentation.ui.main.nonlogin.register.university
+
+import androidx.compose.runtime.Immutable
+import kotlin.coroutines.CoroutineContext
+import kr.linkerbell.campusmarket.android.common.util.coroutine.event.EventFlow
+import kr.linkerbell.campusmarket.android.presentation.model.gallery.GalleryImage
+
+@Immutable
+data class RegisterUniversityArgument(
+    val state: RegisterUniversityState,
+    val event: EventFlow<RegisterUniversityEvent>,
+    val intent: (RegisterUniversityIntent) -> Unit,
+    val logEvent: (eventName: String, params: Map<String, Any>) -> Unit,
+    val coroutineContext: CoroutineContext
+)
+
+sealed interface RegisterUniversityState {
+    data object Init : RegisterUniversityState
+}
+
+sealed interface RegisterUniversityEvent {
+    sealed interface CheckEmail : RegisterUniversityEvent {
+        data object Success : CheckEmail
+        data object Failure : CheckEmail
+    }
+
+    sealed interface CheckVerifyCode : RegisterUniversityEvent {
+        data object Success : CheckVerifyCode
+        data object Failure : CheckVerifyCode
+    }
+}
+
+sealed interface RegisterUniversityIntent {
+    data class OnSendEmail(val email: String) : RegisterUniversityIntent
+    data class OnConfirm(val verifyCode: String) : RegisterUniversityIntent
+}

--- a/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/nonlogin/register/university/RegisterUniversityConstant.kt
+++ b/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/nonlogin/register/university/RegisterUniversityConstant.kt
@@ -1,0 +1,7 @@
+package kr.linkerbell.campusmarket.android.presentation.ui.main.nonlogin.register.university
+
+import kr.linkerbell.campusmarket.android.presentation.ui.main.nonlogin.register.RegisterConstant
+
+object RegisterUniversityConstant {
+    const val ROUTE: String = "${RegisterConstant.ROUTE}/university"
+}

--- a/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/nonlogin/register/university/RegisterUniversityDestination.kt
+++ b/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/nonlogin/register/university/RegisterUniversityDestination.kt
@@ -1,0 +1,37 @@
+package kr.linkerbell.campusmarket.android.presentation.ui.main.nonlogin.register.university
+
+import androidx.compose.runtime.getValue
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.navigation.NavController
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.compose.composable
+import kr.linkerbell.campusmarket.android.presentation.common.util.compose.ErrorObserver
+
+fun NavGraphBuilder.registerUniversityDestination(
+    navController: NavController
+) {
+    composable(
+        route = RegisterUniversityConstant.ROUTE
+    ) {
+        val viewModel: RegisterUniversityViewModel = hiltViewModel()
+
+        val argument: RegisterUniversityArgument = let {
+            val state by viewModel.state.collectAsStateWithLifecycle()
+
+            RegisterUniversityArgument(
+                state = state,
+                event = viewModel.event,
+                intent = viewModel::onIntent,
+                logEvent = viewModel::logEvent,
+                coroutineContext = viewModel.coroutineContext
+            )
+        }
+
+        ErrorObserver(viewModel)
+        RegisterUniversityScreen(
+            navController = navController,
+            argument = argument
+        )
+    }
+}

--- a/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/nonlogin/register/university/RegisterUniversityScreen.kt
+++ b/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/nonlogin/register/university/RegisterUniversityScreen.kt
@@ -1,0 +1,294 @@
+package kr.linkerbell.campusmarket.android.presentation.ui.main.nonlogin.register.university
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableLongStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
+import androidx.navigation.compose.rememberNavController
+import kotlinx.coroutines.CoroutineExceptionHandler
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.plus
+import kr.linkerbell.campusmarket.android.common.util.coroutine.event.MutableEventFlow
+import kr.linkerbell.campusmarket.android.common.util.coroutine.event.eventObserve
+import kr.linkerbell.campusmarket.android.presentation.common.REGEX_EMAIL
+import kr.linkerbell.campusmarket.android.presentation.common.theme.Body1
+import kr.linkerbell.campusmarket.android.presentation.common.theme.Gray900
+import kr.linkerbell.campusmarket.android.presentation.common.theme.Headline0
+import kr.linkerbell.campusmarket.android.presentation.common.theme.Headline2
+import kr.linkerbell.campusmarket.android.presentation.common.theme.Red400
+import kr.linkerbell.campusmarket.android.presentation.common.theme.Space12
+import kr.linkerbell.campusmarket.android.presentation.common.theme.Space20
+import kr.linkerbell.campusmarket.android.presentation.common.theme.Space24
+import kr.linkerbell.campusmarket.android.presentation.common.theme.Space40
+import kr.linkerbell.campusmarket.android.presentation.common.theme.Space44
+import kr.linkerbell.campusmarket.android.presentation.common.theme.Space8
+import kr.linkerbell.campusmarket.android.presentation.common.theme.White
+import kr.linkerbell.campusmarket.android.presentation.common.util.compose.LaunchedEffectWithLifecycle
+import kr.linkerbell.campusmarket.android.presentation.common.util.compose.safeNavigate
+import kr.linkerbell.campusmarket.android.presentation.common.view.confirm.ConfirmButton
+import kr.linkerbell.campusmarket.android.presentation.common.view.confirm.ConfirmButtonProperties
+import kr.linkerbell.campusmarket.android.presentation.common.view.confirm.ConfirmButtonSize
+import kr.linkerbell.campusmarket.android.presentation.common.view.confirm.ConfirmButtonType
+import kr.linkerbell.campusmarket.android.presentation.common.view.textfield.TypingTextField
+import kr.linkerbell.campusmarket.android.presentation.ui.main.nonlogin.entry.EntryConstant
+
+@Composable
+fun RegisterUniversityScreen(
+    navController: NavController,
+    argument: RegisterUniversityArgument
+) {
+    val (state, event, intent, logEvent, coroutineContext) = argument
+    val scope = rememberCoroutineScope() + coroutineContext
+
+    var email: String by rememberSaveable { mutableStateOf("") }
+    var verifyCode: String by rememberSaveable { mutableStateOf("") }
+
+    val isEmailFormValid = email.matches(REGEX_EMAIL.toRegex())
+    var isEmailServerCheckSuccess: Boolean by rememberSaveable { mutableStateOf(true) }
+    var isEmailSend: Boolean by rememberSaveable { mutableStateOf(false) }
+    var isEmailSendButtonLoading: Boolean by rememberSaveable { mutableStateOf(false) }
+    val isEmailSendButtonEnabled =
+        !isEmailSendButtonLoading && email.isNotBlank() && isEmailFormValid && isEmailServerCheckSuccess
+
+    var verifyCodeTimer: Long by rememberSaveable { mutableLongStateOf(0) }
+    var isVerifyCodeServerCheckSuccess: Boolean by rememberSaveable { mutableStateOf(true) }
+    var isConfirmButtonLoading: Boolean by rememberSaveable { mutableStateOf(false) }
+    val isConfirmButtonEnabled =
+        !isConfirmButtonLoading && verifyCode.isNotBlank() && isVerifyCodeServerCheckSuccess && verifyCodeTimer > 0
+
+    fun navigateToEntry() {
+        navController.safeNavigate(EntryConstant.ROUTE) {
+            popUpTo(RegisterUniversityConstant.ROUTE) {
+                inclusive = true
+            }
+        }
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(White),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Spacer(modifier = Modifier.height(100.dp))
+        Text(
+            text = "대학교 이메일 인증",
+            style = Headline0.merge(Gray900)
+        )
+        Spacer(modifier = Modifier.height(Space12))
+        Text(
+            text = "이메일 인증이 필요해요",
+            style = Headline2.merge(Gray900)
+        )
+        Spacer(modifier = Modifier.height(Space40))
+        Row(
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Spacer(modifier = Modifier.width(Space24))
+            TypingTextField(
+                modifier = Modifier.weight(1f),
+                text = email,
+                hintText = "이메일",
+                isError = !isEmailServerCheckSuccess,
+                isEnabled = !isEmailSend,
+                onValueChange = {
+                    email = it
+                    isEmailServerCheckSuccess = true
+                }
+            )
+            Spacer(modifier = Modifier.width(Space12))
+            ConfirmButton(
+                properties = ConfirmButtonProperties(
+                    size = ConfirmButtonSize.Medium,
+                    type = ConfirmButtonType.Primary
+                ),
+                isEnabled = isEmailSendButtonEnabled,
+                onClick = {
+                    isEmailSendButtonLoading = true
+                    intent(
+                        RegisterUniversityIntent.OnSendEmail(
+                            email = email
+                        )
+                    )
+                }
+            ) { style ->
+                if (isEmailSendButtonLoading) {
+                    CircularProgressIndicator(
+                        modifier = Modifier
+                            .size(Space24),
+                        color = White,
+                        strokeWidth = 2.dp
+                    )
+                } else {
+                    Text(
+                        text = "전송",
+                        style = style
+                    )
+                }
+            }
+            Spacer(modifier = Modifier.width(Space24))
+        }
+        if (!isEmailServerCheckSuccess) {
+            Spacer(modifier = Modifier.height(Space8))
+            Text(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = Space44),
+                text = "적절하지 않은 이메일입니다.",
+                style = Body1.merge(Red400),
+            )
+        } else if (!isEmailFormValid && email.isNotBlank()) {
+            Spacer(modifier = Modifier.height(Space8))
+            Text(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = Space44),
+                text = "이메일 형식을 맞춰주세요.",
+                style = Body1.merge(Red400),
+            )
+        }
+        Spacer(modifier = Modifier.height(Space24))
+        TypingTextField(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = Space24),
+            text = verifyCode,
+            hintText = "인증번호",
+            isError = !isVerifyCodeServerCheckSuccess,
+            isEnabled = isEmailSend,
+            onValueChange = {
+                verifyCode = it
+                isVerifyCodeServerCheckSuccess = true
+            }
+        )
+        if (isEmailSend) {
+            Spacer(modifier = Modifier.height(Space8))
+            Text(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = Space44),
+                text = if (verifyCodeTimer > 0) "$verifyCodeTimer 초 남았습니다." else "인증번호가 만료되었습니다.\n다시 전송해주세요.",
+                style = Body1.merge(Gray900),
+            )
+        }
+        Spacer(modifier = Modifier.weight(1f))
+        ConfirmButton(
+            modifier = Modifier
+                .padding(start = Space20, end = Space20, bottom = Space12)
+                .fillMaxWidth(),
+            properties = ConfirmButtonProperties(
+                size = ConfirmButtonSize.Large,
+                type = ConfirmButtonType.Primary
+            ),
+            isEnabled = isConfirmButtonEnabled,
+            onClick = {
+                isConfirmButtonLoading = true
+                intent(
+                    RegisterUniversityIntent.OnConfirm(
+                        verifyCode = verifyCode
+                    )
+                )
+            }
+        ) { style ->
+            if (isConfirmButtonLoading) {
+                CircularProgressIndicator(
+                    modifier = Modifier
+                        .size(Space24),
+                    color = White,
+                    strokeWidth = 2.dp
+                )
+            } else {
+                Text(
+                    text = "다음",
+                    style = style
+                )
+            }
+        }
+    }
+
+    fun checkEmail(event: RegisterUniversityEvent.CheckEmail) {
+        when (event) {
+            RegisterUniversityEvent.CheckEmail.Failure -> {
+                isEmailServerCheckSuccess = false
+                isEmailSendButtonLoading = false
+            }
+
+            RegisterUniversityEvent.CheckEmail.Success -> {
+                isEmailSendButtonLoading = false
+                isEmailSend = true
+                verifyCodeTimer = 300L
+            }
+        }
+    }
+
+    fun checkVerifyCode(event: RegisterUniversityEvent.CheckVerifyCode) {
+        when (event) {
+            RegisterUniversityEvent.CheckVerifyCode.Failure -> {
+                isVerifyCodeServerCheckSuccess = false
+                isConfirmButtonLoading = false
+            }
+
+            RegisterUniversityEvent.CheckVerifyCode.Success -> {
+                isConfirmButtonLoading = false
+                navigateToEntry()
+            }
+        }
+    }
+
+    LaunchedEffectWithLifecycle(event, coroutineContext) {
+        event.eventObserve { event ->
+            when (event) {
+                is RegisterUniversityEvent.CheckEmail -> {
+                    checkEmail(event)
+                }
+
+                is RegisterUniversityEvent.CheckVerifyCode -> {
+                    checkVerifyCode(event)
+                }
+            }
+        }
+    }
+
+    LaunchedEffect(verifyCodeTimer) {
+        if (verifyCodeTimer > 0) {
+            delay(1000)
+            verifyCodeTimer -= 1
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun RegisterUniversityScreenPreview() {
+    RegisterUniversityScreen(
+        navController = rememberNavController(),
+        argument = RegisterUniversityArgument(
+            state = RegisterUniversityState.Init,
+            event = MutableEventFlow(),
+            intent = {},
+            logEvent = { _, _ -> },
+            coroutineContext = CoroutineExceptionHandler { _, _ -> }
+        )
+    )
+}

--- a/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/nonlogin/register/university/RegisterUniversityViewModel.kt
+++ b/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/nonlogin/register/university/RegisterUniversityViewModel.kt
@@ -1,0 +1,85 @@
+package kr.linkerbell.campusmarket.android.presentation.ui.main.nonlogin.register.university
+
+import androidx.lifecycle.SavedStateHandle
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kr.linkerbell.campusmarket.android.common.util.coroutine.event.EventFlow
+import kr.linkerbell.campusmarket.android.common.util.coroutine.event.MutableEventFlow
+import kr.linkerbell.campusmarket.android.common.util.coroutine.event.asEventFlow
+import kr.linkerbell.campusmarket.android.domain.usecase.nonfeature.authentication.SendEmailVerifyCodeUseCase
+import kr.linkerbell.campusmarket.android.domain.usecase.nonfeature.authentication.VerifyEmailVerifyCodeUseCase
+import kr.linkerbell.campusmarket.android.presentation.common.base.BaseViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class RegisterUniversityViewModel @Inject constructor(
+    private val savedStateHandle: SavedStateHandle,
+    private val sendEmailVerifyCodeUseCase: SendEmailVerifyCodeUseCase,
+    private val verifyEmailVerifyCodeUseCase: VerifyEmailVerifyCodeUseCase
+) : BaseViewModel() {
+
+    private val _state: MutableStateFlow<RegisterUniversityState> =
+        MutableStateFlow(RegisterUniversityState.Init)
+    val state: StateFlow<RegisterUniversityState> = _state.asStateFlow()
+
+    private val _event: MutableEventFlow<RegisterUniversityEvent> = MutableEventFlow()
+    val event: EventFlow<RegisterUniversityEvent> = _event.asEventFlow()
+
+    private var token: String
+        get() = savedStateHandle.get<String>(KEY_TOKEN).orEmpty()
+        set(value) {
+            savedStateHandle[KEY_TOKEN] = value
+        }
+
+    fun onIntent(intent: RegisterUniversityIntent) {
+        when (intent) {
+            is RegisterUniversityIntent.OnSendEmail -> {
+                sendEmailVerifyCode(
+                    email = intent.email
+                )
+            }
+
+            is RegisterUniversityIntent.OnConfirm -> {
+                verifyEmailVerifyCode(
+                    verifyCode = intent.verifyCode
+                )
+            }
+        }
+    }
+
+    private fun sendEmailVerifyCode(
+        email: String
+    ) {
+        launch {
+            sendEmailVerifyCodeUseCase(
+                email = email
+            ).onSuccess {
+                token = it
+                _event.emit(RegisterUniversityEvent.CheckEmail.Success)
+            }.onFailure { exception ->
+                _event.emit(RegisterUniversityEvent.CheckEmail.Failure)
+            }
+        }
+    }
+
+    private fun verifyEmailVerifyCode(
+        verifyCode: String
+    ) {
+        launch {
+            verifyEmailVerifyCodeUseCase(
+                token = token,
+                verifyCode = verifyCode
+            ).onSuccess {
+                _event.emit(RegisterUniversityEvent.CheckVerifyCode.Success)
+            }.onFailure { exception ->
+                _event.emit(RegisterUniversityEvent.CheckVerifyCode.Failure)
+            }
+        }
+    }
+
+    companion object {
+        private const val KEY_TOKEN = "key_token"
+    }
+}


### PR DESCRIPTION
## **설명**
- 이메일 인증 관련 API 추가
- 이메일 인증 관련 UI / 로직 추가

## 참고
https://github.com/user-attachments/assets/8b589f2d-5b7b-4437-bf49-70ce5279df50

## 체크리스트
- [x] : 빌드 테스트를 진행하셨나요?
- [x] : 실제 기기에서 테스트를 진행하셨나요?
