### PR TITLE
[CM-14.1] 상품 상세 정보 UI & 로직 (in Progress)

### DIFF
--- a/data/src/main/kotlin/kr/linkerbell/campusmarket/android/data/remote/network/api/feature/TradeApi.kt
+++ b/data/src/main/kotlin/kr/linkerbell/campusmarket/android/data/remote/network/api/feature/TradeApi.kt
@@ -14,7 +14,7 @@ import kr.linkerbell.campusmarket.android.data.remote.network.environment.ErrorM
 import kr.linkerbell.campusmarket.android.data.remote.network.model.feature.trade.CategoryListRes
 import kr.linkerbell.campusmarket.android.data.remote.network.model.feature.trade.DeletedLikedItemRes
 import kr.linkerbell.campusmarket.android.data.remote.network.model.feature.trade.PostLikedItemRes
-import kr.linkerbell.campusmarket.android.data.remote.network.model.feature.trade.PostOrPatchTradeRes
+import kr.linkerbell.campusmarket.android.data.remote.network.model.feature.trade.PostTradeRes
 import kr.linkerbell.campusmarket.android.data.remote.network.model.feature.trade.PostTradeReq
 import kr.linkerbell.campusmarket.android.data.remote.network.model.feature.trade.SearchTradeListRes
 import kr.linkerbell.campusmarket.android.data.remote.network.model.feature.trade.TradeInfoRes
@@ -56,7 +56,7 @@ class TradeApi @Inject constructor(
         category: String,
         thumbnail: String,
         images: List<String>
-    ): Result<PostOrPatchTradeRes> {
+    ): Result<PostTradeRes> {
         return client.post("$baseUrl/api/v1/items") {
             setBody(
                 PostTradeReq(
@@ -74,7 +74,7 @@ class TradeApi @Inject constructor(
     suspend fun patchTradeContents(
         tradeContents: TradeContents,
         itemId: Long
-    ): Result<PostOrPatchTradeRes> {
+    ): Result<Unit> {
         return client.patch("$baseUrl/api/v1/items/$itemId") {
             setBody(
                 PostTradeReq(

--- a/data/src/main/kotlin/kr/linkerbell/campusmarket/android/data/remote/network/api/feature/TradeApi.kt
+++ b/data/src/main/kotlin/kr/linkerbell/campusmarket/android/data/remote/network/api/feature/TradeApi.kt
@@ -1,8 +1,10 @@
 package kr.linkerbell.campusmarket.android.data.remote.network.api.feature
 
 import io.ktor.client.HttpClient
+import io.ktor.client.request.delete
 import io.ktor.client.request.get
 import io.ktor.client.request.parameter
+import io.ktor.client.request.patch
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import javax.inject.Inject
@@ -10,10 +12,14 @@ import kr.linkerbell.campusmarket.android.data.remote.network.di.AuthHttpClient
 import kr.linkerbell.campusmarket.android.data.remote.network.environment.BaseUrlProvider
 import kr.linkerbell.campusmarket.android.data.remote.network.environment.ErrorMessageMapper
 import kr.linkerbell.campusmarket.android.data.remote.network.model.feature.trade.CategoryListRes
+import kr.linkerbell.campusmarket.android.data.remote.network.model.feature.trade.DeletedLikedItemRes
+import kr.linkerbell.campusmarket.android.data.remote.network.model.feature.trade.PostLikedItemRes
+import kr.linkerbell.campusmarket.android.data.remote.network.model.feature.trade.PostOrPatchTradeRes
 import kr.linkerbell.campusmarket.android.data.remote.network.model.feature.trade.PostTradeReq
-import kr.linkerbell.campusmarket.android.data.remote.network.model.feature.trade.PostTradeRes
 import kr.linkerbell.campusmarket.android.data.remote.network.model.feature.trade.SearchTradeListRes
+import kr.linkerbell.campusmarket.android.data.remote.network.model.feature.trade.TradeInfoRes
 import kr.linkerbell.campusmarket.android.data.remote.network.util.convert
+import kr.linkerbell.campusmarket.android.domain.model.feature.trade.TradeContents
 
 class TradeApi @Inject constructor(
     @AuthHttpClient private val client: HttpClient,
@@ -50,7 +56,7 @@ class TradeApi @Inject constructor(
         category: String,
         thumbnail: String,
         images: List<String>
-    ): Result<PostTradeRes> {
+    ): Result<PostOrPatchTradeRes> {
         return client.post("$baseUrl/api/v1/items") {
             setBody(
                 PostTradeReq(
@@ -65,7 +71,42 @@ class TradeApi @Inject constructor(
         }.convert(errorMessageMapper::map)
     }
 
+    suspend fun patchTradeContents(
+        tradeContents: TradeContents,
+        itemId: Long
+    ): Result<PostOrPatchTradeRes> {
+        return client.patch("$baseUrl/api/v1/items/$itemId") {
+            setBody(
+                PostTradeReq(
+                    title = tradeContents.title,
+                    description = tradeContents.description,
+                    price = tradeContents.price,
+                    category = tradeContents.category,
+                    thumbnail = tradeContents.thumbnail,
+                    images = tradeContents.images
+                )
+            )
+        }.convert(errorMessageMapper::map)
+    }
+
     suspend fun getCategoryList(): Result<CategoryListRes> {
         return client.get("$baseUrl/api/v1/items/categories").convert(errorMessageMapper::map)
+    }
+
+    suspend fun getTradeInfo(itemId: Long): Result<TradeInfoRes> {
+        return client.get("$baseUrl/api/v1/items/$itemId").convert(errorMessageMapper::map)
+    }
+
+
+    suspend fun postLikeItem(itemId: Long): Result<PostLikedItemRes> {
+        return client.post("$baseUrl/api/v1/$itemId/likes").convert(errorMessageMapper::map)
+    }
+
+    suspend fun deleteLikedItem(itemId: Long): Result<DeletedLikedItemRes> {
+        return client.delete("$baseUrl/api/v1/$itemId/likes").convert(errorMessageMapper::map)
+    }
+
+    suspend fun deleteTradeInfo(itemId: Long): Result<Unit> {
+        return client.delete("$baseUrl/api/v1/items/$itemId").convert(errorMessageMapper::map)
     }
 }

--- a/data/src/main/kotlin/kr/linkerbell/campusmarket/android/data/remote/network/api/nonfeature/UserApi.kt
+++ b/data/src/main/kotlin/kr/linkerbell/campusmarket/android/data/remote/network/api/nonfeature/UserApi.kt
@@ -62,7 +62,6 @@ class UserApi @Inject constructor(
     suspend fun getUserProfile(
         id: Long
     ): Result<GetUserProfileRes> {
-        return client.get("$baseUrl/api/v1/profile/$id")
-            .convert(errorMessageMapper::map)
+        return client.get("$baseUrl/api/v1/profile/$id").convert(errorMessageMapper::map)
     }
 }

--- a/data/src/main/kotlin/kr/linkerbell/campusmarket/android/data/remote/network/model/feature/trade/DeletedLikedItemRes.kt
+++ b/data/src/main/kotlin/kr/linkerbell/campusmarket/android/data/remote/network/model/feature/trade/DeletedLikedItemRes.kt
@@ -1,0 +1,22 @@
+package kr.linkerbell.campusmarket.android.data.remote.network.model.feature.trade
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kr.linkerbell.campusmarket.android.data.remote.mapper.DataMapper
+import kr.linkerbell.campusmarket.android.domain.model.feature.trade.DeletedLikedItemInfo
+import kr.linkerbell.campusmarket.android.domain.model.feature.trade.LikedItemInfo
+
+@Serializable
+data class DeletedLikedItemRes(
+    @SerialName("itemId")
+    val itemId: Long,
+    @SerialName("isLike")
+    val isLike: Boolean
+) : DataMapper<DeletedLikedItemInfo> {
+    override fun toDomain(): DeletedLikedItemInfo {
+        return DeletedLikedItemInfo(
+            itemId = itemId,
+            isLike = isLike
+        )
+    }
+}

--- a/data/src/main/kotlin/kr/linkerbell/campusmarket/android/data/remote/network/model/feature/trade/PostLikedItemRes.kt
+++ b/data/src/main/kotlin/kr/linkerbell/campusmarket/android/data/remote/network/model/feature/trade/PostLikedItemRes.kt
@@ -1,0 +1,24 @@
+package kr.linkerbell.campusmarket.android.data.remote.network.model.feature.trade
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kr.linkerbell.campusmarket.android.data.remote.mapper.DataMapper
+import kr.linkerbell.campusmarket.android.domain.model.feature.trade.LikedItemInfo
+
+@Serializable
+data class PostLikedItemRes(
+    @SerialName("likeId")
+    val likeId: Long,
+    @SerialName("itemId")
+    val itemId: Long,
+    @SerialName("isLike")
+    val isLike: Boolean
+) : DataMapper<LikedItemInfo> {
+    override fun toDomain(): LikedItemInfo {
+        return LikedItemInfo(
+            likeId = likeId,
+            itemId = itemId,
+            isLike = isLike
+        )
+    }
+}

--- a/data/src/main/kotlin/kr/linkerbell/campusmarket/android/data/remote/network/model/feature/trade/PostOrPatchTradeRes.kt
+++ b/data/src/main/kotlin/kr/linkerbell/campusmarket/android/data/remote/network/model/feature/trade/PostOrPatchTradeRes.kt
@@ -3,7 +3,7 @@ package kr.linkerbell.campusmarket.android.data.remote.network.model.feature.tra
 import kotlinx.serialization.SerialName
 import kr.linkerbell.campusmarket.android.data.remote.mapper.DataMapper
 
-data class PostTradeRes (
+data class PostOrPatchTradeRes (
     @SerialName("itemId")
     val itemId: Long
 ) : DataMapper<Long> {

--- a/data/src/main/kotlin/kr/linkerbell/campusmarket/android/data/remote/network/model/feature/trade/PostTradeRes.kt
+++ b/data/src/main/kotlin/kr/linkerbell/campusmarket/android/data/remote/network/model/feature/trade/PostTradeRes.kt
@@ -1,9 +1,11 @@
 package kr.linkerbell.campusmarket.android.data.remote.network.model.feature.trade
 
 import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
 import kr.linkerbell.campusmarket.android.data.remote.mapper.DataMapper
 
-data class PostOrPatchTradeRes (
+@Serializable
+data class PostTradeRes (
     @SerialName("itemId")
     val itemId: Long
 ) : DataMapper<Long> {

--- a/data/src/main/kotlin/kr/linkerbell/campusmarket/android/data/remote/network/model/feature/trade/SearchTradeListRes.kt
+++ b/data/src/main/kotlin/kr/linkerbell/campusmarket/android/data/remote/network/model/feature/trade/SearchTradeListRes.kt
@@ -3,7 +3,7 @@ package kr.linkerbell.campusmarket.android.data.remote.network.model.feature.tra
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kr.linkerbell.campusmarket.android.data.remote.mapper.DataMapper
-import kr.linkerbell.campusmarket.android.domain.model.feature.trade.Trade
+import kr.linkerbell.campusmarket.android.domain.model.feature.trade.SummarizedTrade
 
 @Serializable
 data class SearchTradeListRes(
@@ -51,9 +51,9 @@ data class SearchTradeListItemRes(
     val likeCount: Int,
     @SerialName("itemStatus")
     val itemStatus: String
-) : DataMapper<Trade> {
-    override fun toDomain(): Trade {
-        return Trade(
+) : DataMapper<SummarizedTrade> {
+    override fun toDomain(): SummarizedTrade {
+        return SummarizedTrade(
             itemId = itemId,
             userId = userId,
             nickname = nickname,

--- a/data/src/main/kotlin/kr/linkerbell/campusmarket/android/data/remote/network/model/feature/trade/TradeInfoRes.kt
+++ b/data/src/main/kotlin/kr/linkerbell/campusmarket/android/data/remote/network/model/feature/trade/TradeInfoRes.kt
@@ -1,0 +1,62 @@
+package kr.linkerbell.campusmarket.android.data.remote.network.model.feature.trade
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kr.linkerbell.campusmarket.android.data.remote.mapper.DataMapper
+import kr.linkerbell.campusmarket.android.domain.model.feature.trade.TradeInfo
+
+@Serializable
+data class TradeInfoRes(
+    @SerialName("itemId")
+    val itemId: Long,
+    @SerialName("userId")
+    val userId: Long,
+    @SerialName("campusId")
+    val campusId: Long,
+    @SerialName("nickname")
+    val nickname: String,
+    @SerialName("title")
+    val title: String,
+    @SerialName("description")
+    val description: String,
+    @SerialName("price")
+    val price: Int,
+    @SerialName("category")
+    val category: String,
+    @SerialName("thumbnail")
+    val thumbnail: String,
+    @SerialName("images")
+    val images: List<String>,
+    @SerialName("chatCount")
+    val chatCount: Int,
+    @SerialName("likeCount")
+    val likeCount: Int,
+    @SerialName("isLiked")
+    val isLiked: Boolean,
+    @SerialName("itemStatus")
+    val itemStatus: String
+) : DataMapper<TradeInfo> {
+    override fun toDomain(): TradeInfo {
+        val isSold = when (itemStatus) {
+            "FORSALE" -> false
+            "SOLDOUT" -> true
+            else -> false
+        }
+        return TradeInfo(
+            itemId = itemId,
+            userId = userId,
+            campusId = campusId,
+            nickname = nickname,
+            title = title,
+            description = description,
+            price = price,
+            category = category,
+            thumbnail = thumbnail,
+            images = images,
+            chatCount = chatCount,
+            likeCount = likeCount,
+            isLiked = isLiked,
+            isSold = isSold
+        )
+    }
+}

--- a/data/src/main/kotlin/kr/linkerbell/campusmarket/android/data/repository/feature/trade/MockTradeRepository.kt
+++ b/data/src/main/kotlin/kr/linkerbell/campusmarket/android/data/repository/feature/trade/MockTradeRepository.kt
@@ -96,7 +96,7 @@ class MockTradeRepository @Inject constructor(
     override suspend fun patchTradeContents(
         tradeContents: TradeContents,
         itemId: Long
-    ): Result<Long> {
+    ): Result<Unit> {
         val newPostContent = "title = ${tradeContents.title}" +
                 "description = ${tradeContents.description}" +
                 "price = ${tradeContents.price}" +
@@ -104,7 +104,7 @@ class MockTradeRepository @Inject constructor(
                 "thumbnail = ${tradeContents.thumbnail}" +
                 "images = ${tradeContents.images}"
         Timber.tag("MockSearchHistoryRepository").d("call patchTradeContents(${newPostContent})")
-        return Result.success(0L)
+        return Result.success(Unit)
     }
 
     override suspend fun getCategoryList(): Result<CategoryList> {

--- a/data/src/main/kotlin/kr/linkerbell/campusmarket/android/data/repository/feature/trade/MockTradeRepository.kt
+++ b/data/src/main/kotlin/kr/linkerbell/campusmarket/android/data/repository/feature/trade/MockTradeRepository.kt
@@ -8,7 +8,11 @@ import kotlinx.coroutines.flow.flowOf
 import kr.linkerbell.campusmarket.android.data.remote.local.database.searchhistory.SearchHistoryDao
 import kr.linkerbell.campusmarket.android.data.remote.local.database.searchhistory.SearchHistoryEntity
 import kr.linkerbell.campusmarket.android.domain.model.feature.trade.CategoryList
-import kr.linkerbell.campusmarket.android.domain.model.feature.trade.Trade
+import kr.linkerbell.campusmarket.android.domain.model.feature.trade.DeletedLikedItemInfo
+import kr.linkerbell.campusmarket.android.domain.model.feature.trade.LikedItemInfo
+import kr.linkerbell.campusmarket.android.domain.model.feature.trade.SummarizedTrade
+import kr.linkerbell.campusmarket.android.domain.model.feature.trade.TradeContents
+import kr.linkerbell.campusmarket.android.domain.model.feature.trade.TradeInfo
 import kr.linkerbell.campusmarket.android.domain.repository.feature.TradeRepository
 import timber.log.Timber
 
@@ -22,13 +26,13 @@ class MockTradeRepository @Inject constructor(
         minPrice: Int,
         maxPrice: Int,
         sorted: String
-    ): Flow<PagingData<Trade>> {
+    ): Flow<PagingData<SummarizedTrade>> {
         randomShortDelay()
 
         return flowOf(
             PagingData.from(
                 listOf(
-                    Trade(
+                    SummarizedTrade(
                         itemId = 1L,
                         userId = 1L,
                         nickname = "장성혁",
@@ -70,7 +74,7 @@ class MockTradeRepository @Inject constructor(
         searchHistoryDao.insert(SearchHistoryEntity(queryString = text))
     }
 
-    override suspend fun postNewTrade(
+    override suspend fun postTradeContents(
         title: String,
         description: String,
         price: Int,
@@ -89,8 +93,38 @@ class MockTradeRepository @Inject constructor(
         return Result.success(0L)
     }
 
+    override suspend fun patchTradeContents(
+        tradeContents: TradeContents,
+        itemId: Long
+    ): Result<Long> {
+        val newPostContent = "title = ${tradeContents.title}" +
+                "description = ${tradeContents.description}" +
+                "price = ${tradeContents.price}" +
+                "category = ${tradeContents.category}" +
+                "thumbnail = ${tradeContents.thumbnail}" +
+                "images = ${tradeContents.images}"
+        Timber.tag("MockSearchHistoryRepository").d("call patchTradeContents(${newPostContent})")
+        return Result.success(0L)
+    }
+
     override suspend fun getCategoryList(): Result<CategoryList> {
         return Result.success(CategoryList.empty)
+    }
+
+    override suspend fun searchTradeInfo(itemId: Long): Result<TradeInfo> {
+        return Result.success(TradeInfo.empty)
+    }
+
+    override suspend fun postLikedItem(itemId: Long): Result<LikedItemInfo> {
+        return Result.success(LikedItemInfo.empty)
+    }
+
+    override suspend fun deleteLikedItem(itemId: Long): Result<DeletedLikedItemInfo> {
+        return Result.success(DeletedLikedItemInfo.empty)
+    }
+
+    override suspend fun deleteTradeInfo(itemId: Long): Result<Unit> {
+        return Result.success(Unit)
     }
 
     private suspend fun randomShortDelay() {

--- a/data/src/main/kotlin/kr/linkerbell/campusmarket/android/data/repository/feature/trade/RealTradeRepository.kt
+++ b/data/src/main/kotlin/kr/linkerbell/campusmarket/android/data/repository/feature/trade/RealTradeRepository.kt
@@ -13,7 +13,11 @@ import kr.linkerbell.campusmarket.android.data.remote.network.api.feature.TradeA
 import kr.linkerbell.campusmarket.android.data.remote.network.util.toDomain
 import kr.linkerbell.campusmarket.android.data.repository.feature.trade.paging.SearchTradePagingSource
 import kr.linkerbell.campusmarket.android.domain.model.feature.trade.CategoryList
-import kr.linkerbell.campusmarket.android.domain.model.feature.trade.Trade
+import kr.linkerbell.campusmarket.android.domain.model.feature.trade.DeletedLikedItemInfo
+import kr.linkerbell.campusmarket.android.domain.model.feature.trade.LikedItemInfo
+import kr.linkerbell.campusmarket.android.domain.model.feature.trade.SummarizedTrade
+import kr.linkerbell.campusmarket.android.domain.model.feature.trade.TradeContents
+import kr.linkerbell.campusmarket.android.domain.model.feature.trade.TradeInfo
 import kr.linkerbell.campusmarket.android.domain.repository.feature.TradeRepository
 
 class RealTradeRepository @Inject constructor(
@@ -27,7 +31,7 @@ class RealTradeRepository @Inject constructor(
         minPrice: Int,
         maxPrice: Int,
         sorted: String
-    ): Flow<PagingData<Trade>> {
+    ): Flow<PagingData<SummarizedTrade>> {
         return Pager(
             config = PagingConfig(
                 pageSize = DEFAULT_PAGING_SIZE,
@@ -66,7 +70,7 @@ class RealTradeRepository @Inject constructor(
         searchHistoryDao.insert(SearchHistoryEntity(queryString = text))
     }
 
-    override suspend fun postNewTrade(
+    override suspend fun postTradeContents(
         title: String,
         description: String,
         price: Int,
@@ -78,7 +82,30 @@ class RealTradeRepository @Inject constructor(
             .toDomain()
     }
 
+    override suspend fun patchTradeContents(
+        tradeContents: TradeContents,
+        itemId: Long
+    ): Result<Long> {
+        return tradeApi.patchTradeContents(tradeContents, itemId).toDomain()
+    }
+
     override suspend fun getCategoryList(): Result<CategoryList> {
         return tradeApi.getCategoryList().toDomain()
+    }
+
+    override suspend fun searchTradeInfo(itemId: Long): Result<TradeInfo> {
+        return tradeApi.getTradeInfo(itemId).toDomain()
+    }
+
+    override suspend fun postLikedItem(itemId: Long): Result<LikedItemInfo> {
+        return tradeApi.postLikeItem(itemId).toDomain()
+    }
+
+    override suspend fun deleteLikedItem(itemId: Long): Result<DeletedLikedItemInfo> {
+        return tradeApi.deleteLikedItem(itemId).toDomain()
+    }
+
+    override suspend fun deleteTradeInfo(itemId: Long): Result<Unit> {
+        return tradeApi.deleteTradeInfo(itemId)
     }
 }

--- a/data/src/main/kotlin/kr/linkerbell/campusmarket/android/data/repository/feature/trade/RealTradeRepository.kt
+++ b/data/src/main/kotlin/kr/linkerbell/campusmarket/android/data/repository/feature/trade/RealTradeRepository.kt
@@ -85,8 +85,8 @@ class RealTradeRepository @Inject constructor(
     override suspend fun patchTradeContents(
         tradeContents: TradeContents,
         itemId: Long
-    ): Result<Long> {
-        return tradeApi.patchTradeContents(tradeContents, itemId).toDomain()
+    ): Result<Unit> {
+        return tradeApi.patchTradeContents(tradeContents, itemId)
     }
 
     override suspend fun getCategoryList(): Result<CategoryList> {

--- a/data/src/main/kotlin/kr/linkerbell/campusmarket/android/data/repository/feature/trade/paging/SearchTradePagingSource.kt
+++ b/data/src/main/kotlin/kr/linkerbell/campusmarket/android/data/repository/feature/trade/paging/SearchTradePagingSource.kt
@@ -4,7 +4,7 @@ import androidx.paging.PagingSource
 import androidx.paging.PagingState
 import kr.linkerbell.campusmarket.android.data.common.DEFAULT_PAGE_START
 import kr.linkerbell.campusmarket.android.data.remote.network.api.feature.TradeApi
-import kr.linkerbell.campusmarket.android.domain.model.feature.trade.Trade
+import kr.linkerbell.campusmarket.android.domain.model.feature.trade.SummarizedTrade
 
 class SearchTradePagingSource(
     private val tradeApi: TradeApi,
@@ -13,16 +13,16 @@ class SearchTradePagingSource(
     private val minPrice: Int,
     private val maxPrice: Int,
     private val sorted: String,
-) : PagingSource<Int, Trade>() {
+) : PagingSource<Int, SummarizedTrade>() {
 
-    override fun getRefreshKey(state: PagingState<Int, Trade>): Int? {
+    override fun getRefreshKey(state: PagingState<Int, SummarizedTrade>): Int? {
         return state.anchorPosition?.let { anchorPosition ->
             state.closestPageToPosition(anchorPosition)?.prevKey?.plus(1)
                 ?: state.closestPageToPosition(anchorPosition)?.nextKey?.minus(1)
         }
     }
 
-    override suspend fun load(params: LoadParams<Int>): LoadResult<Int, Trade> {
+    override suspend fun load(params: LoadParams<Int>): LoadResult<Int, SummarizedTrade> {
         val pageNum = params.key ?: DEFAULT_PAGE_START
         val pageSize = params.loadSize
 

--- a/domain/src/main/kotlin/kr/linkerbell/campusmarket/android/domain/model/feature/trade/DeletedLikedItemInfo.kt
+++ b/domain/src/main/kotlin/kr/linkerbell/campusmarket/android/domain/model/feature/trade/DeletedLikedItemInfo.kt
@@ -1,0 +1,13 @@
+package kr.linkerbell.campusmarket.android.domain.model.feature.trade
+
+data class DeletedLikedItemInfo(
+    val itemId: Long,
+    val isLike: Boolean
+) {
+    companion object {
+        val empty = DeletedLikedItemInfo(
+            itemId = 0,
+            isLike = false
+        )
+    }
+}

--- a/domain/src/main/kotlin/kr/linkerbell/campusmarket/android/domain/model/feature/trade/LikedItemInfo.kt
+++ b/domain/src/main/kotlin/kr/linkerbell/campusmarket/android/domain/model/feature/trade/LikedItemInfo.kt
@@ -1,0 +1,15 @@
+package kr.linkerbell.campusmarket.android.domain.model.feature.trade
+
+data class LikedItemInfo(
+    val likeId: Long,
+    val itemId: Long,
+    val isLike: Boolean
+) {
+    companion object {
+        val empty = LikedItemInfo(
+            likeId = 0,
+            itemId = 0,
+            isLike = false
+        )
+    }
+}

--- a/domain/src/main/kotlin/kr/linkerbell/campusmarket/android/domain/model/feature/trade/SummarizedTrade.kt
+++ b/domain/src/main/kotlin/kr/linkerbell/campusmarket/android/domain/model/feature/trade/SummarizedTrade.kt
@@ -1,6 +1,6 @@
 package kr.linkerbell.campusmarket.android.domain.model.feature.trade
 
-data class Trade(
+data class SummarizedTrade(
     val itemId: Long,
     val userId: Long,
     val nickname: String,
@@ -12,7 +12,7 @@ data class Trade(
     val itemStatus: String
 ) {
     companion object {
-        val empty = Trade(
+        val empty = SummarizedTrade(
             itemId = 0,
             userId = 0,
             nickname = "",

--- a/domain/src/main/kotlin/kr/linkerbell/campusmarket/android/domain/model/feature/trade/TradeContents.kt
+++ b/domain/src/main/kotlin/kr/linkerbell/campusmarket/android/domain/model/feature/trade/TradeContents.kt
@@ -1,0 +1,21 @@
+package kr.linkerbell.campusmarket.android.domain.model.feature.trade
+
+data class TradeContents(
+    val title: String,
+    val description: String,
+    val price: Int,
+    val category: String,
+    val thumbnail: String,
+    val images: List<String>
+) {
+    companion object {
+        val empty = TradeContents(
+            title = "",
+            description = "",
+            price = 0,
+            category = "OTHER",
+            thumbnail = "",
+            images = listOf("")
+        )
+    }
+}

--- a/domain/src/main/kotlin/kr/linkerbell/campusmarket/android/domain/model/feature/trade/TradeInfo.kt
+++ b/domain/src/main/kotlin/kr/linkerbell/campusmarket/android/domain/model/feature/trade/TradeInfo.kt
@@ -1,0 +1,37 @@
+package kr.linkerbell.campusmarket.android.domain.model.feature.trade
+
+data class TradeInfo(
+    val itemId: Long,
+    val userId: Long,
+    val campusId: Long,
+    val nickname: String,
+    val title: String,
+    val description: String,
+    val price: Int,
+    val category: String,
+    val thumbnail: String,
+    val images: List<String>,
+    val chatCount: Int,
+    val likeCount: Int,
+    val isLiked: Boolean,
+    val isSold: Boolean,
+) {
+    companion object {
+        val empty = TradeInfo(
+            itemId = 0,
+            userId = 0,
+            campusId = 0,
+            nickname = "dummy user",
+            title = "title",
+            description = "description",
+            price = 0,
+            category = "OTHER",
+            thumbnail = "",
+            images = emptyList(),
+            chatCount = 0,
+            likeCount = 0,
+            isLiked = false,
+            isSold = false,
+        )
+    }
+}

--- a/domain/src/main/kotlin/kr/linkerbell/campusmarket/android/domain/repository/feature/TradeRepository.kt
+++ b/domain/src/main/kotlin/kr/linkerbell/campusmarket/android/domain/repository/feature/TradeRepository.kt
@@ -3,7 +3,11 @@ package kr.linkerbell.campusmarket.android.domain.repository.feature
 import androidx.paging.PagingData
 import kotlinx.coroutines.flow.Flow
 import kr.linkerbell.campusmarket.android.domain.model.feature.trade.CategoryList
-import kr.linkerbell.campusmarket.android.domain.model.feature.trade.Trade
+import kr.linkerbell.campusmarket.android.domain.model.feature.trade.DeletedLikedItemInfo
+import kr.linkerbell.campusmarket.android.domain.model.feature.trade.LikedItemInfo
+import kr.linkerbell.campusmarket.android.domain.model.feature.trade.SummarizedTrade
+import kr.linkerbell.campusmarket.android.domain.model.feature.trade.TradeContents
+import kr.linkerbell.campusmarket.android.domain.model.feature.trade.TradeInfo
 
 interface TradeRepository {
 
@@ -13,7 +17,7 @@ interface TradeRepository {
         minPrice: Int,
         maxPrice: Int,
         sorted: String
-    ): Flow<PagingData<Trade>>
+    ): Flow<PagingData<SummarizedTrade>>
 
     suspend fun getSearchHistoryList(): Flow<List<String>>
 
@@ -23,7 +27,7 @@ interface TradeRepository {
 
     suspend fun addSearchHistory(text: String)
 
-    suspend fun postNewTrade(
+    suspend fun postTradeContents(
         title: String,
         description: String,
         price: Int,
@@ -32,5 +36,15 @@ interface TradeRepository {
         images: List<String>
     ): Result<Long>
 
+    suspend fun patchTradeContents(tradeContents: TradeContents, itemId: Long): Result<Long>
+
     suspend fun getCategoryList(): Result<CategoryList>
+
+    suspend fun searchTradeInfo(itemId: Long): Result<TradeInfo>
+
+    suspend fun postLikedItem(itemId: Long): Result<LikedItemInfo>
+
+    suspend fun deleteLikedItem(itemId: Long): Result<DeletedLikedItemInfo>
+
+    suspend fun deleteTradeInfo(itemId: Long): Result<Unit>
 }

--- a/domain/src/main/kotlin/kr/linkerbell/campusmarket/android/domain/repository/feature/TradeRepository.kt
+++ b/domain/src/main/kotlin/kr/linkerbell/campusmarket/android/domain/repository/feature/TradeRepository.kt
@@ -36,7 +36,7 @@ interface TradeRepository {
         images: List<String>
     ): Result<Long>
 
-    suspend fun patchTradeContents(tradeContents: TradeContents, itemId: Long): Result<Long>
+    suspend fun patchTradeContents(tradeContents: TradeContents, itemId: Long): Result<Unit>
 
     suspend fun getCategoryList(): Result<CategoryList>
 

--- a/domain/src/main/kotlin/kr/linkerbell/campusmarket/android/domain/usecase/feature/trade/DeleteLikedItemUseCase.kt
+++ b/domain/src/main/kotlin/kr/linkerbell/campusmarket/android/domain/usecase/feature/trade/DeleteLikedItemUseCase.kt
@@ -7,7 +7,9 @@ import kr.linkerbell.campusmarket.android.domain.repository.feature.TradeReposit
 class DeleteLikedItemUseCase @Inject constructor(
     private val tradeRepository: TradeRepository
 ) {
-    suspend operator fun invoke(itemId: Long): Result<DeletedLikedItemInfo> {
+    suspend operator fun invoke(
+        itemId: Long
+    ): Result<DeletedLikedItemInfo> {
         return tradeRepository.deleteLikedItem(itemId)
     }
 }

--- a/domain/src/main/kotlin/kr/linkerbell/campusmarket/android/domain/usecase/feature/trade/DeleteLikedItemUseCase.kt
+++ b/domain/src/main/kotlin/kr/linkerbell/campusmarket/android/domain/usecase/feature/trade/DeleteLikedItemUseCase.kt
@@ -1,0 +1,13 @@
+package kr.linkerbell.campusmarket.android.domain.usecase.feature.trade
+
+import javax.inject.Inject
+import kr.linkerbell.campusmarket.android.domain.model.feature.trade.DeletedLikedItemInfo
+import kr.linkerbell.campusmarket.android.domain.repository.feature.TradeRepository
+
+class DeleteLikedItemUseCase @Inject constructor(
+    private val tradeRepository: TradeRepository
+) {
+    suspend operator fun invoke(itemId: Long): Result<DeletedLikedItemInfo> {
+        return tradeRepository.deleteLikedItem(itemId)
+    }
+}

--- a/domain/src/main/kotlin/kr/linkerbell/campusmarket/android/domain/usecase/feature/trade/DeleteTradeInfoUseCase.kt
+++ b/domain/src/main/kotlin/kr/linkerbell/campusmarket/android/domain/usecase/feature/trade/DeleteTradeInfoUseCase.kt
@@ -1,0 +1,18 @@
+package kr.linkerbell.campusmarket.android.domain.usecase.feature.trade
+
+import javax.inject.Inject
+import kotlinx.coroutines.flow.Flow
+import kr.linkerbell.campusmarket.android.domain.model.feature.trade.TradeInfo
+import kr.linkerbell.campusmarket.android.domain.repository.feature.TradeRepository
+
+class DeleteTradeInfoUseCase @Inject constructor(
+    private val tradeRepository: TradeRepository
+){
+    suspend operator fun invoke(
+        itemId: Long
+    ): Result<Unit> {
+        return tradeRepository.deleteTradeInfo(
+            itemId = itemId
+        )
+    }
+}

--- a/domain/src/main/kotlin/kr/linkerbell/campusmarket/android/domain/usecase/feature/trade/DeleteTradeInfoUseCase.kt
+++ b/domain/src/main/kotlin/kr/linkerbell/campusmarket/android/domain/usecase/feature/trade/DeleteTradeInfoUseCase.kt
@@ -1,13 +1,11 @@
 package kr.linkerbell.campusmarket.android.domain.usecase.feature.trade
 
 import javax.inject.Inject
-import kotlinx.coroutines.flow.Flow
-import kr.linkerbell.campusmarket.android.domain.model.feature.trade.TradeInfo
 import kr.linkerbell.campusmarket.android.domain.repository.feature.TradeRepository
 
 class DeleteTradeInfoUseCase @Inject constructor(
     private val tradeRepository: TradeRepository
-){
+) {
     suspend operator fun invoke(
         itemId: Long
     ): Result<Unit> {

--- a/domain/src/main/kotlin/kr/linkerbell/campusmarket/android/domain/usecase/feature/trade/GetTradeInfoUseCase.kt
+++ b/domain/src/main/kotlin/kr/linkerbell/campusmarket/android/domain/usecase/feature/trade/GetTradeInfoUseCase.kt
@@ -1,13 +1,12 @@
 package kr.linkerbell.campusmarket.android.domain.usecase.feature.trade
 
 import javax.inject.Inject
-import kotlinx.coroutines.flow.Flow
 import kr.linkerbell.campusmarket.android.domain.model.feature.trade.TradeInfo
 import kr.linkerbell.campusmarket.android.domain.repository.feature.TradeRepository
 
 class GetTradeInfoUseCase @Inject constructor(
     private val tradeRepository: TradeRepository
-){
+) {
     suspend operator fun invoke(
         itemId: Long
     ): Result<TradeInfo> {

--- a/domain/src/main/kotlin/kr/linkerbell/campusmarket/android/domain/usecase/feature/trade/GetTradeInfoUseCase.kt
+++ b/domain/src/main/kotlin/kr/linkerbell/campusmarket/android/domain/usecase/feature/trade/GetTradeInfoUseCase.kt
@@ -1,0 +1,18 @@
+package kr.linkerbell.campusmarket.android.domain.usecase.feature.trade
+
+import javax.inject.Inject
+import kotlinx.coroutines.flow.Flow
+import kr.linkerbell.campusmarket.android.domain.model.feature.trade.TradeInfo
+import kr.linkerbell.campusmarket.android.domain.repository.feature.TradeRepository
+
+class GetTradeInfoUseCase @Inject constructor(
+    private val tradeRepository: TradeRepository
+){
+    suspend operator fun invoke(
+        itemId: Long
+    ): Result<TradeInfo> {
+        return tradeRepository.searchTradeInfo(
+            itemId = itemId
+        )
+    }
+}

--- a/domain/src/main/kotlin/kr/linkerbell/campusmarket/android/domain/usecase/feature/trade/PatchTradeContentsUseCase.kt
+++ b/domain/src/main/kotlin/kr/linkerbell/campusmarket/android/domain/usecase/feature/trade/PatchTradeContentsUseCase.kt
@@ -8,7 +8,8 @@ class PatchTradeContentsUseCase @Inject constructor(
     private val tradeRepository: TradeRepository
 ) {
     suspend operator fun invoke(
-        tradeContents: TradeContents, itemId: Long
+        tradeContents: TradeContents,
+        itemId: Long
     ): Result<Long> {
         return tradeRepository.patchTradeContents(tradeContents, itemId)
     }

--- a/domain/src/main/kotlin/kr/linkerbell/campusmarket/android/domain/usecase/feature/trade/PatchTradeContentsUseCase.kt
+++ b/domain/src/main/kotlin/kr/linkerbell/campusmarket/android/domain/usecase/feature/trade/PatchTradeContentsUseCase.kt
@@ -1,0 +1,15 @@
+package kr.linkerbell.campusmarket.android.domain.usecase.feature.trade
+
+import javax.inject.Inject
+import kr.linkerbell.campusmarket.android.domain.model.feature.trade.TradeContents
+import kr.linkerbell.campusmarket.android.domain.repository.feature.TradeRepository
+
+class PatchTradeContentsUseCase @Inject constructor(
+    private val tradeRepository: TradeRepository
+) {
+    suspend operator fun invoke(
+        tradeContents: TradeContents, itemId: Long
+    ): Result<Long> {
+        return tradeRepository.patchTradeContents(tradeContents, itemId)
+    }
+}

--- a/domain/src/main/kotlin/kr/linkerbell/campusmarket/android/domain/usecase/feature/trade/PatchTradeContentsUseCase.kt
+++ b/domain/src/main/kotlin/kr/linkerbell/campusmarket/android/domain/usecase/feature/trade/PatchTradeContentsUseCase.kt
@@ -10,7 +10,7 @@ class PatchTradeContentsUseCase @Inject constructor(
     suspend operator fun invoke(
         tradeContents: TradeContents,
         itemId: Long
-    ): Result<Long> {
+    ): Result<Unit> {
         return tradeRepository.patchTradeContents(tradeContents, itemId)
     }
 }

--- a/domain/src/main/kotlin/kr/linkerbell/campusmarket/android/domain/usecase/feature/trade/PostLikedItemUseCase.kt
+++ b/domain/src/main/kotlin/kr/linkerbell/campusmarket/android/domain/usecase/feature/trade/PostLikedItemUseCase.kt
@@ -7,7 +7,9 @@ import kr.linkerbell.campusmarket.android.domain.repository.feature.TradeReposit
 class PostLikedItemUseCase @Inject constructor(
     private val tradeRepository: TradeRepository
 ) {
-    suspend operator fun invoke(itemId: Long): Result<LikedItemInfo> {
+    suspend operator fun invoke(
+        itemId: Long
+    ): Result<LikedItemInfo> {
         return tradeRepository.postLikedItem(itemId)
     }
 }

--- a/domain/src/main/kotlin/kr/linkerbell/campusmarket/android/domain/usecase/feature/trade/PostLikedItemUseCase.kt
+++ b/domain/src/main/kotlin/kr/linkerbell/campusmarket/android/domain/usecase/feature/trade/PostLikedItemUseCase.kt
@@ -1,0 +1,13 @@
+package kr.linkerbell.campusmarket.android.domain.usecase.feature.trade
+
+import javax.inject.Inject
+import kr.linkerbell.campusmarket.android.domain.model.feature.trade.LikedItemInfo
+import kr.linkerbell.campusmarket.android.domain.repository.feature.TradeRepository
+
+class PostLikedItemUseCase @Inject constructor(
+    private val tradeRepository: TradeRepository
+) {
+    suspend operator fun invoke(itemId: Long): Result<LikedItemInfo> {
+        return tradeRepository.postLikedItem(itemId)
+    }
+}

--- a/domain/src/main/kotlin/kr/linkerbell/campusmarket/android/domain/usecase/feature/trade/PostTradeContentsUseCase.kt
+++ b/domain/src/main/kotlin/kr/linkerbell/campusmarket/android/domain/usecase/feature/trade/PostTradeContentsUseCase.kt
@@ -3,7 +3,7 @@ package kr.linkerbell.campusmarket.android.domain.usecase.feature.trade
 import javax.inject.Inject
 import kr.linkerbell.campusmarket.android.domain.repository.feature.TradeRepository
 
-class PostNewTradeUseCase @Inject constructor(
+class PostTradeContentsUseCase @Inject constructor(
     private val tradeRepository: TradeRepository
 ) {
     suspend operator fun invoke(
@@ -14,7 +14,7 @@ class PostNewTradeUseCase @Inject constructor(
         thumbnail: String,
         images: List<String>
     ): Result<Long> {
-        return tradeRepository.postNewTrade(
+        return tradeRepository.postTradeContents(
             title = title,
             description = description,
             price = price,

--- a/domain/src/main/kotlin/kr/linkerbell/campusmarket/android/domain/usecase/feature/trade/SearchTradeListUseCase.kt
+++ b/domain/src/main/kotlin/kr/linkerbell/campusmarket/android/domain/usecase/feature/trade/SearchTradeListUseCase.kt
@@ -3,7 +3,7 @@ package kr.linkerbell.campusmarket.android.domain.usecase.feature.trade
 import androidx.paging.PagingData
 import javax.inject.Inject
 import kotlinx.coroutines.flow.Flow
-import kr.linkerbell.campusmarket.android.domain.model.feature.trade.Trade
+import kr.linkerbell.campusmarket.android.domain.model.feature.trade.SummarizedTrade
 import kr.linkerbell.campusmarket.android.domain.repository.feature.TradeRepository
 
 class SearchTradeListUseCase @Inject constructor(
@@ -15,7 +15,7 @@ class SearchTradeListUseCase @Inject constructor(
         minPrice: Int,
         maxPrice: Int,
         sorted: String
-    ): Flow<PagingData<Trade>> {
+    ): Flow<PagingData<SummarizedTrade>> {
         return tradeRepository.searchTradeList(
             name = name,
             category = category,

--- a/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/MainDestination.kt
+++ b/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/MainDestination.kt
@@ -5,6 +5,7 @@ import androidx.navigation.NavGraphBuilder
 import kr.linkerbell.campusmarket.android.presentation.ui.main.home.chatroom.chat.chatDestination
 import kr.linkerbell.campusmarket.android.presentation.ui.main.home.homeDestination
 import kr.linkerbell.campusmarket.android.presentation.ui.main.home.schedule.compare.scheduleCompareDestination
+import kr.linkerbell.campusmarket.android.presentation.ui.main.home.trade.info.tradeInfoDestination
 import kr.linkerbell.campusmarket.android.presentation.ui.main.home.trade.post.tradePostDestination
 import kr.linkerbell.campusmarket.android.presentation.ui.main.home.trade.search.result.tradeSearchResultDestination
 import kr.linkerbell.campusmarket.android.presentation.ui.main.home.trade.search.tradeSearchDestination
@@ -21,6 +22,7 @@ fun NavGraphBuilder.mainDestination(
     tradeSearchDestination(navController = navController)
     tradeSearchResultDestination(navController = navController)
     tradePostDestination(navController = navController)
+    tradeInfoDestination(navController = navController)
 
     chatDestination(navController = navController)
 

--- a/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/trade/TradeData.kt
+++ b/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/trade/TradeData.kt
@@ -2,9 +2,9 @@ package kr.linkerbell.campusmarket.android.presentation.ui.main.home.trade
 
 import androidx.compose.runtime.Immutable
 import androidx.paging.compose.LazyPagingItems
-import kr.linkerbell.campusmarket.android.domain.model.feature.trade.Trade
+import kr.linkerbell.campusmarket.android.domain.model.feature.trade.SummarizedTrade
 
 @Immutable
 data class TradeData(
-    val tradeList: LazyPagingItems<Trade>
+    val summarizedTradeList: LazyPagingItems<SummarizedTrade>
 )

--- a/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/trade/TradeScreen.kt
+++ b/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/trade/TradeScreen.kt
@@ -22,8 +22,10 @@ import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.FavoriteBorder
 import androidx.compose.material.icons.filled.Notifications
 import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.FabPosition
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -101,59 +103,60 @@ private fun TradeScreen(
     val (state, event, intent, logEvent, coroutineContext) = argument
     val scope = rememberCoroutineScope() + coroutineContext
 
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .background(Indigo50)
-    ) {
-        TradeSearchBar {
-            navController.navigate(TradeSearchConstant.ROUTE)
-        }
-        LazyColumn(
-            contentPadding = PaddingValues(vertical = 16.dp, horizontal = 20.dp)
-        ) {
-            itemsIndexed(
-                items = data.summarizedTradeList.itemSnapshotList,
-                key = { _, item -> item?.itemId ?: -1 }
-            ) { _, trade ->
-                trade?.let {
-                    TradeItemCard(
-                        item = it,
-                        onItemCardClicked = {
-                            val tradeInfoRoute = makeRoute(
-                                route = TradeInfoConstant.ROUTE,
-                                arguments = mapOf(
-                                    TradeInfoConstant.ROUTE_ARGUMENT_ITEM_ID to trade.itemId.toString()
-                                )
-                            )
-                            navController.navigate(tradeInfoRoute)
-                        }
+    Scaffold(
+        topBar = {
+            TradeSearchBar {
+                navController.navigate(TradeSearchConstant.ROUTE)
+            }
+        },
+        floatingActionButton = {
+            TradeScreenPostButton(
+                onClick = {
+                    val postRoute = makeRoute(
+                        route = TradePostConstant.ROUTE,
+                        arguments = mapOf(
+                            TradePostConstant.ROUTE_ARGUMENT_ITEM_ID to "-1"
+                        )
                     )
-                    Spacer(modifier = Modifier.height(8.dp))
+                    navController.navigate(postRoute)
+                }
+            )
+        },
+        floatingActionButtonPosition = FabPosition.End,
+    ){innerPadding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(Indigo50)
+                .padding(innerPadding)
+        ) {
+            LazyColumn(
+                modifier = Modifier.weight(1f),
+                contentPadding = PaddingValues(vertical = 16.dp, horizontal = 20.dp)
+            ) {
+                itemsIndexed(
+                    items = data.summarizedTradeList.itemSnapshotList,
+                    key = { _, item -> item?.itemId ?: -1 }
+                ) { _, trade ->
+                    trade?.let {
+                        TradeItemCard(
+                            item = it,
+                            onItemCardClicked = {
+                                val tradeInfoRoute = makeRoute(
+                                    route = TradeInfoConstant.ROUTE,
+                                    arguments = mapOf(
+                                        TradeInfoConstant.ROUTE_ARGUMENT_ITEM_ID to trade.itemId.toString()
+                                    )
+                                )
+                                navController.navigate(tradeInfoRoute)
+                            }
+                        )
+                        Spacer(modifier = Modifier.height(8.dp))
+                    }
                 }
             }
         }
     }
-
-    Box(
-        modifier = Modifier
-            .padding(32.dp)
-            .fillMaxSize(),
-        contentAlignment = Alignment.BottomEnd
-    ) {
-        TradeScreenPostButton(
-            onClick = {
-                val postRoute = makeRoute(
-                    route = TradePostConstant.ROUTE,
-                    arguments = mapOf(
-                        TradePostConstant.ROUTE_ARGUMENT_ITEM_ID to "-1"
-                    )
-                )
-                navController.navigate(postRoute)
-            }
-        )
-    }
-
 }
 
 @Composable

--- a/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/trade/TradeScreen.kt
+++ b/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/trade/TradeScreen.kt
@@ -49,6 +49,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.plus
 import kr.linkerbell.campusmarket.android.common.util.coroutine.event.MutableEventFlow
 import kr.linkerbell.campusmarket.android.domain.model.feature.trade.SummarizedTrade
+import kr.linkerbell.campusmarket.android.presentation.common.theme.Black
 import kr.linkerbell.campusmarket.android.presentation.common.theme.Caption2
 import kr.linkerbell.campusmarket.android.presentation.common.theme.Gray50
 import kr.linkerbell.campusmarket.android.presentation.common.theme.Headline3
@@ -123,7 +124,7 @@ private fun TradeScreen(
             )
         },
         floatingActionButtonPosition = FabPosition.End,
-    ){innerPadding ->
+    ) { innerPadding ->
         Column(
             modifier = Modifier
                 .fillMaxSize()
@@ -200,6 +201,7 @@ private fun TradeItemCard(
                         Text(
                             text = item.title,
                             style = Headline3,
+                            color = Black,
                             overflow = TextOverflow.Ellipsis,
                             maxLines = 1,
                             modifier = Modifier.weight(1f),
@@ -207,26 +209,37 @@ private fun TradeItemCard(
                         Spacer(modifier = Modifier.padding(4.dp))
                         TradeItemStatus(isSold = item.itemStatus === "FORSALE")
                     }
-                    Text("${item.price} 원", modifier = Modifier.padding(start = 8.dp))
+                    Text(
+                        "${item.price} 원",
+                        color = Black,
+                        modifier = Modifier.padding(start = 8.dp)
+                    )
                 }
                 Text(
                     text = item.nickname,
                     style = Caption2,
+                    color = Black,
                     modifier = Modifier.padding(bottom = 4.dp)
                 )
                 Text(
                     text = "${item.chatCount} 명이 대화중",
                     style = Caption2,
+                    color = Black,
                     modifier = Modifier.padding(bottom = 4.dp)
                 )
                 Row(verticalAlignment = Alignment.CenterVertically) {
                     Icon(
                         imageVector = Icons.Default.FavoriteBorder,
                         contentDescription = "Home",
+                        tint = Black,
                         modifier = Modifier.size(12.dp)
                     )
                     Spacer(modifier = Modifier.padding(2.dp))
-                    Text(item.likeCount.toString())
+                    Text(
+                        item.likeCount.toString(),
+                        color = Black,
+                        style = Caption2
+                    )
                 }
             }
         }
@@ -275,6 +288,7 @@ private fun TradeSearchBar(
             ) {
                 Text(
                     text = "검색어를 입력하세요",
+                    color = Black,
                     modifier = Modifier.padding(start = 16.dp)
                 )
                 Icon(

--- a/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/trade/TradeScreen.kt
+++ b/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/trade/TradeScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
@@ -111,48 +112,61 @@ private fun TradeScreen(
         LazyColumn(
             contentPadding = PaddingValues(vertical = 16.dp, horizontal = 20.dp)
         ) {
-            items(
-                count = data.summarizedTradeList.itemCount,
-                key = { index -> data.summarizedTradeList[index]?.itemId ?: -1 }
-            ) { index ->
-                val trade = data.summarizedTradeList[index] ?: return@items
-                TradeItemCard(
-                    item = trade,
-                    navigateToTradeInfoScreen = {
-                        val tradeInfoRoute = makeRoute(
-                            route = TradeInfoConstant.ROUTE,
-                            arguments = mapOf(
-                                TradeInfoConstant.ROUTE_ARGUMENT_ITEM_ID to trade.itemId.toString()
+            itemsIndexed(
+                items = data.summarizedTradeList.itemSnapshotList,
+                key = { _, item -> item?.itemId ?: -1 }
+            ) { _, trade ->
+                trade?.let {
+                    TradeItemCard(
+                        item = it,
+                        onItemCardClicked = {
+                            val tradeInfoRoute = makeRoute(
+                                route = TradeInfoConstant.ROUTE,
+                                arguments = mapOf(
+                                    TradeInfoConstant.ROUTE_ARGUMENT_ITEM_ID to trade.itemId.toString()
+                                )
                             )
-                        )
-                        navController.navigate(tradeInfoRoute)
-                    }
-                )
-                Spacer(modifier = Modifier.height(8.dp))
+                            navController.navigate(tradeInfoRoute)
+                        }
+                    )
+                    Spacer(modifier = Modifier.height(8.dp))
+                }
             }
         }
     }
+
     Box(
         modifier = Modifier
             .padding(32.dp)
             .fillMaxSize(),
         contentAlignment = Alignment.BottomEnd
     ) {
-        TradeScreenPostButton(onClick = { navController.navigate(TradePostConstant.ROUTE) })
+        TradeScreenPostButton(
+            onClick = {
+                val postRoute = makeRoute(
+                    route = TradePostConstant.ROUTE,
+                    arguments = mapOf(
+                        TradePostConstant.ROUTE_ARGUMENT_ITEM_ID to "-1"
+                    )
+                )
+                navController.navigate(postRoute)
+            }
+        )
     }
+
 }
 
 @Composable
 private fun TradeItemCard(
     item: SummarizedTrade,
-    navigateToTradeInfoScreen: (Long) -> Unit
+    onItemCardClicked: (Long) -> Unit
 ) {
     Box(
         Modifier
             .shadow(4.dp)
             .clip(RoundedCornerShape(5.dp))
             .clickable {
-                navigateToTradeInfoScreen(item.itemId)
+                onItemCardClicked(item.itemId)
             }
     ) {
         Row(

--- a/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/trade/TradeScreen.kt
+++ b/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/trade/TradeScreen.kt
@@ -58,8 +58,6 @@ import kr.linkerbell.campusmarket.android.presentation.ui.main.home.trade.info.T
 import kr.linkerbell.campusmarket.android.presentation.ui.main.home.trade.post.TradePostConstant
 import kr.linkerbell.campusmarket.android.presentation.ui.main.home.trade.search.TradeSearchConstant
 
-//TODO(변경사항 많은지 체크)
-
 @Composable
 fun TradeScreen(
     navController: NavController,

--- a/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/trade/TradeViewModel.kt
+++ b/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/trade/TradeViewModel.kt
@@ -12,7 +12,7 @@ import kotlinx.coroutines.flow.catch
 import kr.linkerbell.campusmarket.android.common.util.coroutine.event.EventFlow
 import kr.linkerbell.campusmarket.android.common.util.coroutine.event.MutableEventFlow
 import kr.linkerbell.campusmarket.android.common.util.coroutine.event.asEventFlow
-import kr.linkerbell.campusmarket.android.domain.model.feature.trade.Trade
+import kr.linkerbell.campusmarket.android.domain.model.feature.trade.SummarizedTrade
 import kr.linkerbell.campusmarket.android.domain.model.nonfeature.error.ServerException
 import kr.linkerbell.campusmarket.android.domain.usecase.feature.trade.SearchTradeListUseCase
 import kr.linkerbell.campusmarket.android.presentation.common.base.BaseViewModel
@@ -31,9 +31,9 @@ class TradeViewModel @Inject constructor(
     private val _event: MutableEventFlow<TradeScreenEvent> = MutableEventFlow()
     val event: EventFlow<TradeScreenEvent> = _event.asEventFlow()
 
-    private val _tradeList: MutableStateFlow<PagingData<Trade>> =
+    private val _summarizedTradeList: MutableStateFlow<PagingData<SummarizedTrade>> =
         MutableStateFlow(PagingData.empty())
-    val tradeList: StateFlow<PagingData<Trade>> = _tradeList.asStateFlow()
+    val summarizedTradeList: StateFlow<PagingData<SummarizedTrade>> = _summarizedTradeList.asStateFlow()
 
     init {
         launch {
@@ -56,7 +56,7 @@ class TradeViewModel @Inject constructor(
                         }
                     }
                 }.collect {
-                    _tradeList.value = it
+                    _summarizedTradeList.value = it
                 }
         }
     }

--- a/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/trade/TradeViewModel.kt
+++ b/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/trade/TradeViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import androidx.paging.PagingData
 import androidx.paging.cachedIn
 import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -17,7 +18,6 @@ import kr.linkerbell.campusmarket.android.domain.model.nonfeature.error.ServerEx
 import kr.linkerbell.campusmarket.android.domain.usecase.feature.trade.SearchTradeListUseCase
 import kr.linkerbell.campusmarket.android.presentation.common.base.BaseViewModel
 import kr.linkerbell.campusmarket.android.presentation.common.base.ErrorEvent
-import javax.inject.Inject
 
 @HiltViewModel
 class TradeViewModel @Inject constructor(
@@ -33,7 +33,8 @@ class TradeViewModel @Inject constructor(
 
     private val _summarizedTradeList: MutableStateFlow<PagingData<SummarizedTrade>> =
         MutableStateFlow(PagingData.empty())
-    val summarizedTradeList: StateFlow<PagingData<SummarizedTrade>> = _summarizedTradeList.asStateFlow()
+    val summarizedTradeList: StateFlow<PagingData<SummarizedTrade>> =
+        _summarizedTradeList.asStateFlow()
 
     init {
         launch {

--- a/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/trade/info/TradeInfoArgument.kt
+++ b/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/trade/info/TradeInfoArgument.kt
@@ -21,6 +21,7 @@ sealed interface TradeInfoState {
 
 sealed interface TradeInfoEvent {
     data class NavigateToChatRoom(val id: Long) : TradeInfoEvent
+    data object FailedToFetchData: TradeInfoEvent
 }
 
 sealed interface TradeInfoIntent {

--- a/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/trade/info/TradeInfoArgument.kt
+++ b/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/trade/info/TradeInfoArgument.kt
@@ -1,0 +1,27 @@
+package kr.linkerbell.campusmarket.android.presentation.ui.main.home.trade.info
+
+import androidx.compose.runtime.Immutable
+import kotlin.coroutines.CoroutineContext
+import kr.linkerbell.campusmarket.android.common.util.coroutine.event.EventFlow
+
+@Immutable
+data class TradeInfoArgument(
+    val state: TradeInfoState,
+    val event: EventFlow<TradeInfoEvent>,
+    val intent: (TradeInfoIntent) -> Unit,
+    val logEvent: (eventName: String, params: Map<String, Any>) -> Unit,
+    val coroutineContext: CoroutineContext
+)
+
+sealed interface TradeInfoState {
+    data object Init : TradeInfoState
+    data object Loading : TradeInfoState
+}
+
+
+sealed interface TradeInfoEvent
+
+sealed interface TradeInfoIntent {
+    data object LikeButtonClicked : TradeInfoIntent
+    data object DeleteThisPost : TradeInfoIntent
+}

--- a/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/trade/info/TradeInfoArgument.kt
+++ b/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/trade/info/TradeInfoArgument.kt
@@ -19,9 +19,12 @@ sealed interface TradeInfoState {
 }
 
 
-sealed interface TradeInfoEvent
+sealed interface TradeInfoEvent {
+    data class NavigateToChatRoom(val id: Long) : TradeInfoEvent
+}
 
 sealed interface TradeInfoIntent {
     data object LikeButtonClicked : TradeInfoIntent
     data object DeleteThisPost : TradeInfoIntent
+    data object OnTradeStart : TradeInfoIntent
 }

--- a/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/trade/info/TradeInfoConstant.kt
+++ b/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/trade/info/TradeInfoConstant.kt
@@ -1,0 +1,11 @@
+package kr.linkerbell.campusmarket.android.presentation.ui.main.home.trade.info
+
+import kr.linkerbell.campusmarket.android.presentation.ui.main.home.trade.TradeConstant
+
+object TradeInfoConstant {
+
+    const val ROUTE = "${TradeConstant.ROUTE}/info"
+    const val ROUTE_ARGUMENT_ITEM_ID = "itemId"
+
+    const val ROUTE_STRUCTURE = "$ROUTE?$ROUTE_ARGUMENT_ITEM_ID={$ROUTE_ARGUMENT_ITEM_ID}"
+}

--- a/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/trade/info/TradeInfoData.kt
+++ b/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/trade/info/TradeInfoData.kt
@@ -1,0 +1,13 @@
+package kr.linkerbell.campusmarket.android.presentation.ui.main.home.trade.info
+
+import androidx.compose.runtime.Immutable
+import kr.linkerbell.campusmarket.android.domain.model.feature.trade.TradeInfo
+import kr.linkerbell.campusmarket.android.domain.model.nonfeature.user.MyProfile
+import kr.linkerbell.campusmarket.android.domain.model.nonfeature.user.UserProfile
+
+@Immutable
+data class TradeInfoData(
+    val tradeInfo: TradeInfo,
+    val authorInfo: UserProfile,
+    val userInfo: MyProfile
+)

--- a/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/trade/info/TradeInfoDestination.kt
+++ b/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/trade/info/TradeInfoDestination.kt
@@ -1,0 +1,55 @@
+package kr.linkerbell.campusmarket.android.presentation.ui.main.home.trade.info
+
+import androidx.compose.runtime.getValue
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.navigation.NavController
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavType
+import androidx.navigation.compose.composable
+import androidx.navigation.navArgument
+import kr.linkerbell.campusmarket.android.presentation.common.util.compose.ErrorObserver
+
+fun NavGraphBuilder.tradeInfoDestination(
+    navController: NavController
+) {
+    composable(
+        route = TradeInfoConstant.ROUTE_STRUCTURE,
+        arguments = listOf(
+            navArgument("itemId") { type = NavType.StringType; defaultValue = "0" },
+        )
+    ) {
+        val viewModel: TradeInfoViewModel = hiltViewModel()
+
+        val argument: TradeInfoArgument = let {
+            val state by viewModel.state.collectAsStateWithLifecycle()
+
+            TradeInfoArgument(
+                state = state,
+                event = viewModel.event,
+                intent = viewModel::onIntent,
+                logEvent = viewModel::logEvent,
+                coroutineContext = viewModel.coroutineContext
+            )
+        }
+
+        val data: TradeInfoData = let {
+            val tradeInfo by viewModel.tradeInfo.collectAsStateWithLifecycle()
+            val authorInfo by viewModel.authorInfo.collectAsStateWithLifecycle()
+            val userInfo by viewModel.userInfo.collectAsStateWithLifecycle()
+
+            TradeInfoData(
+                tradeInfo = tradeInfo,
+                authorInfo = authorInfo,
+                userInfo = userInfo
+            )
+        }
+
+        ErrorObserver(viewModel)
+        TradeInfoScreen(
+            navController = navController,
+            argument = argument,
+            data = data
+        )
+    }
+}

--- a/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/trade/info/TradeInfoDestination.kt
+++ b/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/trade/info/TradeInfoDestination.kt
@@ -16,9 +16,9 @@ fun NavGraphBuilder.tradeInfoDestination(
     composable(
         route = TradeInfoConstant.ROUTE_STRUCTURE,
         arguments = listOf(
-            navArgument("itemId") {
+            navArgument(TradeInfoConstant.ROUTE_ARGUMENT_ITEM_ID) {
                 type = NavType.LongType
-                defaultValue = -1
+                defaultValue = -1L
             }
         )
     ) {

--- a/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/trade/info/TradeInfoDestination.kt
+++ b/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/trade/info/TradeInfoDestination.kt
@@ -16,7 +16,10 @@ fun NavGraphBuilder.tradeInfoDestination(
     composable(
         route = TradeInfoConstant.ROUTE_STRUCTURE,
         arguments = listOf(
-            navArgument("itemId") { type = NavType.StringType; defaultValue = "0" },
+            navArgument("itemId") {
+                type = NavType.StringType
+                defaultValue = "0"
+            }
         )
     ) {
         val viewModel: TradeInfoViewModel = hiltViewModel()

--- a/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/trade/info/TradeInfoDestination.kt
+++ b/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/trade/info/TradeInfoDestination.kt
@@ -17,8 +17,8 @@ fun NavGraphBuilder.tradeInfoDestination(
         route = TradeInfoConstant.ROUTE_STRUCTURE,
         arguments = listOf(
             navArgument("itemId") {
-                type = NavType.StringType
-                defaultValue = "0"
+                type = NavType.LongType
+                defaultValue = -1
             }
         )
     ) {

--- a/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/trade/info/TradeInfoScreen.kt
+++ b/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/trade/info/TradeInfoScreen.kt
@@ -1,0 +1,520 @@
+package kr.linkerbell.campusmarket.android.presentation.ui.main.home.trade.info
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material.icons.filled.FavoriteBorder
+import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
+import androidx.navigation.compose.rememberNavController
+import kotlinx.coroutines.CoroutineExceptionHandler
+import kotlinx.coroutines.plus
+import kr.linkerbell.campusmarket.android.common.util.coroutine.event.MutableEventFlow
+import kr.linkerbell.campusmarket.android.domain.model.feature.trade.TradeInfo
+import kr.linkerbell.campusmarket.android.domain.model.nonfeature.user.MyProfile
+import kr.linkerbell.campusmarket.android.domain.model.nonfeature.user.UserProfile
+import kr.linkerbell.campusmarket.android.presentation.R
+import kr.linkerbell.campusmarket.android.presentation.common.theme.Black
+import kr.linkerbell.campusmarket.android.presentation.common.theme.Blue400
+import kr.linkerbell.campusmarket.android.presentation.common.theme.BlueGray200
+import kr.linkerbell.campusmarket.android.presentation.common.theme.BlueGray50
+import kr.linkerbell.campusmarket.android.presentation.common.theme.Body1
+import kr.linkerbell.campusmarket.android.presentation.common.theme.Headline2
+import kr.linkerbell.campusmarket.android.presentation.common.theme.Headline3
+import kr.linkerbell.campusmarket.android.presentation.common.theme.Indigo50
+import kr.linkerbell.campusmarket.android.presentation.common.theme.White
+import kr.linkerbell.campusmarket.android.presentation.common.util.compose.makeRoute
+import kr.linkerbell.campusmarket.android.presentation.common.util.compose.safeNavigateUp
+import kr.linkerbell.campusmarket.android.presentation.common.view.DialogScreen
+import kr.linkerbell.campusmarket.android.presentation.common.view.image.PostImage
+import kr.linkerbell.campusmarket.android.presentation.ui.main.home.trade.post.TradePostConstant
+
+@Composable
+fun TradeInfoScreen(
+    navController: NavController,
+    argument: TradeInfoArgument,
+    data: TradeInfoData
+) {
+    val (state, event, intent, logEvent, coroutineContext) = argument
+    val scope = rememberCoroutineScope() + coroutineContext
+
+    val tradeInfo = data.tradeInfo
+    val authorInfo = data.authorInfo
+    val isOwnerOfThisTrade = (data.userInfo.id == authorInfo.id)
+
+    var isDeleteConfirmButtonVisible by remember { mutableStateOf(false) }
+
+    val onChatButtonClick: () -> Unit = {
+        //TODO(Ray Jang : tradeInfo.itemId 기반으로 채팅 시작 로직)
+    }
+
+    Scaffold(
+        topBar = {
+            TradeInfoTopBar(
+                isOwnerOfThisTrade = isOwnerOfThisTrade,
+                onNavigatePreviousScreenButton = { navController.popBackStack() },
+                reportArticle = { }, //신고 페이지로
+                deleteArticle = {
+                    isDeleteConfirmButtonVisible = true
+                },
+                patchArticle = {
+                    val newRoute = makeRoute(
+                        route = TradePostConstant.ROUTE,
+                        arguments = mapOf(
+                            TradePostConstant.ROUTE_ARGUMENT_ITEM_ID to tradeInfo.itemId.toString()
+                        )
+                    )
+                    navController.navigate(newRoute)
+                }
+            )
+        },
+        bottomBar = {
+            TradeInfoBottomBar(
+                isLiked = tradeInfo.isLiked,
+                isSold = tradeInfo.isSold,
+                price = tradeInfo.price,
+                onLikeButtonClick = {
+                    argument.intent(TradeInfoIntent.LikeButtonClicked)
+                },
+                onChatButtonClick = onChatButtonClick
+            )
+        }
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState())
+                .padding(innerPadding)
+                .background(Indigo50)
+        ) {
+            TradeInfoImageViewer(
+                thumbUrl = tradeInfo.thumbnail,
+                imageUrls = tradeInfo.images
+            )
+            TradeInfoAuthor(
+                authorInfo,
+                authorNickname = tradeInfo.nickname
+            )
+            TradeInfoContent(
+                title = tradeInfo.title,
+                description = tradeInfo.description,
+                category = tradeInfo.category,
+                likeCount = tradeInfo.likeCount,
+                chatCount = tradeInfo.chatCount
+            )
+        }
+
+        if (isDeleteConfirmButtonVisible) {
+            if (isOwnerOfThisTrade) {
+                DialogScreen(
+                    title = "게시글이 삭제되었습니다!",
+                    isCancelable = true,
+                    onConfirm = {
+                        argument.intent(TradeInfoIntent.DeleteThisPost)
+                    },
+                    onDismissRequest = {
+                        isDeleteConfirmButtonVisible = false
+                        navController.safeNavigateUp()
+                    }
+                )
+            } else {
+                DialogScreen(
+                    title = "삭제 권한이 없습니다",
+                    isCancelable = false,
+                    onDismissRequest = {
+                        isDeleteConfirmButtonVisible = false
+                    }
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun TradeInfoTopBar(
+    isOwnerOfThisTrade: Boolean,
+    onNavigatePreviousScreenButton: () -> Unit,
+    reportArticle: () -> Unit,
+    patchArticle: () -> Unit,
+    deleteArticle: () -> Unit,
+) {
+    var isDropDownExpanded by remember { mutableStateOf(false) }
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .border(1.dp, Color.Gray)
+            .background(Color.Transparent)
+            .height(56.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Icon(
+                painter = painterResource(id = R.drawable.ic_chevron_left),
+                contentDescription = "Navigate Up Button",
+                tint = BlueGray50,
+                modifier = Modifier
+                    .size(48.dp)
+                    .clickable {
+                        onNavigatePreviousScreenButton()
+                    }
+                    .padding(horizontal = 8.dp)
+            )
+            Text(
+                text = "상세 정보",
+                style = Headline2,
+                color = BlueGray50
+            )
+        }
+        Box {
+            Icon(
+                imageVector = Icons.Default.MoreVert,
+                tint = BlueGray50,
+                contentDescription = "More Option Button",
+                modifier = Modifier
+                    .size(48.dp)
+                    .clickable {
+                        isDropDownExpanded = !isDropDownExpanded
+                    }
+                    .padding(horizontal = 8.dp)
+            )
+            val userOption = if (isOwnerOfThisTrade) {
+                listOf("신고", "삭제", "수정")
+            } else {
+                listOf("신고")
+            }
+
+            DropdownMenu(
+                expanded = isDropDownExpanded,
+                onDismissRequest = { isDropDownExpanded = false },
+            ) {
+                userOption.forEach { option ->
+                    DropdownMenuItem(
+                        text = {
+                            Text(text = option)
+                        },
+                        onClick = {
+                            isDropDownExpanded = false
+                            when (option) {
+                                "신고" -> {
+                                    reportArticle()
+                                }
+
+                                "삭제" -> {
+                                    deleteArticle()
+                                }
+
+                                "수정" -> {
+                                    patchArticle()
+                                }
+                            }
+                        }
+                    )
+                }
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+private fun TradeInfoImageViewer(thumbUrl: String, imageUrls: List<String>) {
+
+    val pagerState = rememberPagerState(pageCount = { imageUrls.size + 1 })
+    val thumbnailAndImage = listOf(thumbUrl) + imageUrls
+
+    HorizontalPager(
+        state = pagerState,
+        modifier = Modifier
+            .fillMaxWidth()
+            .heightIn(min = 200.dp)
+    ) { page ->
+        PostImage(
+            data = thumbnailAndImage[page],
+            modifier = Modifier.clip(shape = RoundedCornerShape(0))
+        )
+    }
+}
+
+@Composable
+private fun TradeInfoAuthor(
+    authorInfo: UserProfile,
+    authorNickname: String
+) {
+    Row(
+        modifier = Modifier
+            .border(2.dp, Color.Gray)
+            .padding(horizontal = 16.dp, vertical = 16.dp)
+            .fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Row(
+            modifier = Modifier
+                .clickable {
+                    //TODO(사용자 프로필 보여주는 화면으로 이동)
+                },
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            PostImage(
+                data = authorInfo.profileImage,
+                modifier = Modifier
+                    .size(32.dp)
+                    .clip(RoundedCornerShape(8.dp))
+                    .border(1.dp, Color.Gray, RoundedCornerShape(8.dp))
+            )
+            Text(
+                text = authorNickname,
+                style = Headline3,
+                color = Black,
+                modifier = Modifier.padding(start = 8.dp)
+            )
+        }
+        Text(text = "${authorInfo.rating} 점", color = Black, style = Headline3)
+    }
+
+}
+
+@Composable
+private fun TradeInfoContent(
+    title: String,
+    description: String,
+    category: String,
+    likeCount: Int,
+    chatCount: Int
+) {
+    Column(
+        modifier = Modifier
+            .padding(16.dp)
+            .fillMaxWidth()
+    ) {
+        val spacerPadding = 4.dp
+
+        Text(text = title, color = Black, style = Headline2)
+        Spacer(Modifier.padding(spacerPadding))
+
+        Text(text = translateToKor(category), color = Black, style = Body1)
+        Spacer(Modifier.padding(spacerPadding))
+
+        Text(text = "$likeCount 명이 좋아함", color = Black, style = Body1)
+        Spacer(Modifier.padding(spacerPadding))
+
+        Text(text = "$chatCount 명이 관심 있어함", color = Black, style = Body1)
+        Spacer(Modifier.padding(spacerPadding))
+
+        HorizontalDivider(thickness = (0.4).dp, color = Black)
+
+        Spacer(Modifier.padding(spacerPadding))
+        Text(text = description, color = Black, style = Body1)
+    }
+}
+
+@Composable
+private fun TradeInfoBottomBar(
+    isLiked: Boolean,
+    price: Int,
+    isSold: Boolean,
+    onLikeButtonClick: () -> Unit,
+    onChatButtonClick: () -> Unit,
+) {
+
+    val favIcon = if (isLiked) Icons.Default.Favorite else Icons.Default.FavoriteBorder
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .border(1.dp, Color.Gray)
+            .background(White),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Row(
+            modifier = Modifier.padding(horizontal = 8.dp, vertical = 16.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Icon(
+                imageVector = favIcon,
+                contentDescription = "Fav Icon",
+                tint = Blue400,
+                modifier = Modifier
+                    .size(36.dp)
+                    .padding(end = 8.dp)
+                    .clickable {
+                        onLikeButtonClick()
+                    }
+            )
+            Text(text = "$price 원", color = Black, style = Headline3)
+        }
+        Row(
+            modifier = Modifier.padding(8.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            TradeItemStatus(isSold)
+            Spacer(Modifier.padding(8.dp))
+            TradeStartButton(isSold, onChatButtonClick)
+        }
+    }
+}
+
+@Composable
+private fun TradeItemStatus(
+    isSold: Boolean
+) {
+    if (isSold) {
+        Box(
+            modifier = Modifier
+                .clip(RoundedCornerShape(5.dp))
+                .background(Color.Gray),
+            contentAlignment = Alignment.Center
+        ) {
+            Text("거래 완료", modifier = Modifier.padding(horizontal = 4.dp, vertical = 1.dp))
+        }
+    } else {
+        Box(
+            modifier = Modifier
+                .clip(RoundedCornerShape(5.dp))
+                .background(Color.LightGray)
+        ) {
+            Text("거래중", modifier = Modifier.padding(horizontal = 4.dp, vertical = 1.dp))
+        }
+    }
+}
+
+@Composable
+private fun TradeStartButton(
+    isSold: Boolean,
+    onChatButtonClick: () -> Unit,
+) {
+
+    if (isSold) {
+        Row(
+            modifier = Modifier
+                .clip(RoundedCornerShape(4.dp))
+                .background(BlueGray200),
+            horizontalArrangement = Arrangement.Center
+        ) {
+            Text(
+                text = "거래 완료",
+                modifier = Modifier.padding(8.dp),
+                style = Headline2,
+                color = Color.White
+            )
+        }
+    } else {
+        Row(
+            modifier = Modifier
+                .clip(RoundedCornerShape(4.dp))
+                .background(Blue400)
+                .clickable {
+                    onChatButtonClick()
+                },
+            horizontalArrangement = Arrangement.Center
+        ) {
+            Text(
+                text = "거래하기",
+                modifier = Modifier.padding(vertical = 8.dp, horizontal = 28.dp),
+                style = Headline2,
+                color = Color.White
+            )
+        }
+    }
+}
+
+private fun translateToKor(engCategory: String): String {
+    return when (engCategory) {
+        "ELECTRONICS_IT" -> "전자기기/IT"
+        "HOME_APPLIANCES" -> "가전제품"
+        "FASHION_ACCESSORIES" -> "패션/액세서리"
+        "ACCESSORIES" -> "액세서리"
+        "BOOKS_EDUCATIONAL_MATERIALS" -> "서적/교육 자료"
+        "STATIONERY_OFFICE_SUPPLIES" -> "문구/사무용품"
+        "HOUSEHOLD_ITEMS" -> "생활용품"
+        "KITCHEN_SUPPLIES" -> "주방용품"
+        "FURNITURE_INTERIOR" -> "가구/인테리어"
+        "SPORTS_LEISURE" -> "스포츠/레저"
+        "ENTERTAINMENT_HOBBIES" -> "엔터테인먼트/취미"
+        "OTHER" -> "기타"
+        else -> "기타"
+    }
+}
+
+@Preview
+@Composable
+private fun TradeInfoScreenPreview() {
+    TradeInfoScreen(
+        navController = rememberNavController(),
+        argument = TradeInfoArgument(
+            state = TradeInfoState.Init,
+            event = MutableEventFlow(),
+            intent = {},
+            logEvent = { _, _ -> },
+            coroutineContext = CoroutineExceptionHandler { _, _ -> }
+        ),
+        data = TradeInfoData(
+            authorInfo = UserProfile(
+                id = 2001L,
+                nickname = "SampleUser",
+                profileImage = "https://www.google.com/url?sa=i&url=https%3A%2F%2Fnamu.wiki%2Fw%2F%25EB%25AA%25B0%253F%25EB%25A3%25A8&psig=AOvVaw0ZvXnvVvoooyjWzrpOLFTi&ust=1731290975363000&source=images&cd=vfe&opi=89978449&ved=0CBEQjRxqFwoTCOj6oM_X0IkDFQAAAAAdAAAAABAE",
+                rating = 4.5
+            ),
+            tradeInfo = TradeInfo(
+                campusId = 1L,
+                itemId = 1001L,
+                userId = 2001L,
+                thumbnail = "https://item.kakaocdn.net/do/28a77143f3d25e892bda83e00c6f828a960f4ab09fe6e38bae8c63030c9b37f9",
+                images = listOf(
+                    "https://fastly.picsum.photos/id/63/250/250.jpg?hmac=hyyougRhLlxGL-aRzyFGfh6hW9_lWjkHMHlKodqU0ik",
+                    "https://fastly.picsum.photos/id/63/250/250.jpg?hmac=hyyougRhLlxGL-aRzyFGfh6hW9_lWjkHMHlKodqU0ik"
+                ),
+                nickname = "SampleUser",
+                title = "Example Item",
+                category = "ELECTRONICS_IT",
+                description = "대충 상품에 대한 설명입니다. 사장님이 맛있고 음식이 친절해요 어쩌고",
+                chatCount = 5,
+                likeCount = 20,
+                price = 15000,
+                isLiked = true,
+                isSold = false
+            ),
+            userInfo = MyProfile.empty
+        )
+    )
+}

--- a/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/trade/info/TradeInfoScreen.kt
+++ b/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/trade/info/TradeInfoScreen.kt
@@ -87,13 +87,7 @@ fun TradeInfoScreen(
     var isFailedToFetchDataDialogVisible by remember { mutableStateOf(false) }
 
     fun navigateToChatRoom(id: Long) {
-        val route = makeRoute(
-            ChatConstant.ROUTE,
-            listOf(
-                ChatConstant.ROUTE_ARGUMENT_ROOM_ID to id.toString()
-            )
-        )
-        navController.navigate(route)
+        navController.navigate("${ChatConstant.ROUTE}/$id")
     }
 
     Scaffold(

--- a/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/trade/info/TradeInfoScreen.kt
+++ b/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/trade/info/TradeInfoScreen.kt
@@ -84,6 +84,7 @@ fun TradeInfoScreen(
     val isOwnerOfThisTrade = (data.userInfo.id == authorInfo.id)
 
     var isDeleteConfirmButtonVisible by remember { mutableStateOf(false) }
+    var isFailedToFetchDataDialogVisible by remember { mutableStateOf(false) }
 
     fun navigateToChatRoom(id: Long) {
         val route = makeRoute(
@@ -154,9 +155,11 @@ fun TradeInfoScreen(
         }
 
         if (isDeleteConfirmButtonVisible) {
+
             if (isOwnerOfThisTrade) {
                 DialogScreen(
-                    title = "게시글이 삭제되었습니다!",
+                    title = "정말 삭제하시겠습니까?",
+                    message = "등록된 정보가 사라집니다.",
                     isCancelable = true,
                     onConfirm = {
                         argument.intent(TradeInfoIntent.DeleteThisPost)
@@ -178,11 +181,21 @@ fun TradeInfoScreen(
         }
     }
 
+    if (isFailedToFetchDataDialogVisible) {
+        FailedToFetchDataDialog(
+            onDismissRequest = { isDeleteConfirmButtonVisible = false }
+        )
+    }
+
     LaunchedEffectWithLifecycle(event, coroutineContext) {
         event.eventObserve { event ->
             when (event) {
                 is TradeInfoEvent.NavigateToChatRoom -> {
                     navigateToChatRoom(id = event.id)
+                }
+
+                is TradeInfoEvent.FailedToFetchData -> {
+
                 }
             }
         }
@@ -497,6 +510,20 @@ private fun translateToKor(engCategory: String): String {
         "OTHER" -> "기타"
         else -> "기타"
     }
+}
+
+@Composable
+private fun FailedToFetchDataDialog(
+    onDismissRequest: () -> Unit
+) {
+    DialogScreen(
+        title = "상품 조회 실패!",
+        message = "데이터를 가져오는데 실패했습니다.",
+        isCancelable = false,
+        onDismissRequest = {
+            onDismissRequest()
+        }
+    )
 }
 
 @Preview

--- a/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/trade/info/TradeInfoScreen.kt
+++ b/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/trade/info/TradeInfoScreen.kt
@@ -48,6 +48,7 @@ import androidx.navigation.compose.rememberNavController
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.plus
 import kr.linkerbell.campusmarket.android.common.util.coroutine.event.MutableEventFlow
+import kr.linkerbell.campusmarket.android.common.util.coroutine.event.eventObserve
 import kr.linkerbell.campusmarket.android.domain.model.feature.trade.TradeInfo
 import kr.linkerbell.campusmarket.android.domain.model.nonfeature.user.MyProfile
 import kr.linkerbell.campusmarket.android.domain.model.nonfeature.user.UserProfile
@@ -60,10 +61,12 @@ import kr.linkerbell.campusmarket.android.presentation.common.theme.Headline2
 import kr.linkerbell.campusmarket.android.presentation.common.theme.Headline3
 import kr.linkerbell.campusmarket.android.presentation.common.theme.Indigo50
 import kr.linkerbell.campusmarket.android.presentation.common.theme.White
+import kr.linkerbell.campusmarket.android.presentation.common.util.compose.LaunchedEffectWithLifecycle
 import kr.linkerbell.campusmarket.android.presentation.common.util.compose.makeRoute
 import kr.linkerbell.campusmarket.android.presentation.common.util.compose.safeNavigateUp
 import kr.linkerbell.campusmarket.android.presentation.common.view.DialogScreen
 import kr.linkerbell.campusmarket.android.presentation.common.view.image.PostImage
+import kr.linkerbell.campusmarket.android.presentation.ui.main.home.chatroom.chat.ChatConstant
 import kr.linkerbell.campusmarket.android.presentation.ui.main.home.trade.post.TradePostConstant
 
 @Composable
@@ -81,8 +84,14 @@ fun TradeInfoScreen(
 
     var isDeleteConfirmButtonVisible by remember { mutableStateOf(false) }
 
-    val onChatButtonClick: () -> Unit = {
-        //TODO(Ray Jang : tradeInfo.itemId 기반으로 채팅 시작 로직)
+    fun navigateToChatRoom(id: Long) {
+        val route = makeRoute(
+            ChatConstant.ROUTE,
+            listOf(
+                ChatConstant.ROUTE_ARGUMENT_ROOM_ID to id.toString()
+            )
+        )
+        navController.navigate(route)
     }
 
     Scaffold(
@@ -113,7 +122,9 @@ fun TradeInfoScreen(
                 onLikeButtonClick = {
                     argument.intent(TradeInfoIntent.LikeButtonClicked)
                 },
-                onChatButtonClick = onChatButtonClick
+                onChatButtonClick = {
+                    argument.intent(TradeInfoIntent.OnTradeStart)
+                }
             )
         }
     ) { innerPadding ->
@@ -162,6 +173,16 @@ fun TradeInfoScreen(
                         isDeleteConfirmButtonVisible = false
                     }
                 )
+            }
+        }
+    }
+
+    LaunchedEffectWithLifecycle(event, coroutineContext) {
+        event.eventObserve { event ->
+            when (event) {
+                is TradeInfoEvent.NavigateToChatRoom -> {
+                    navigateToChatRoom(id = event.id)
+                }
             }
         }
     }

--- a/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/trade/info/TradeInfoScreen.kt
+++ b/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/trade/info/TradeInfoScreen.kt
@@ -63,6 +63,7 @@ import kr.linkerbell.campusmarket.android.presentation.common.theme.Indigo50
 import kr.linkerbell.campusmarket.android.presentation.common.theme.White
 import kr.linkerbell.campusmarket.android.presentation.common.util.compose.LaunchedEffectWithLifecycle
 import kr.linkerbell.campusmarket.android.presentation.common.util.compose.makeRoute
+import kr.linkerbell.campusmarket.android.presentation.common.util.compose.safeNavigate
 import kr.linkerbell.campusmarket.android.presentation.common.util.compose.safeNavigateUp
 import kr.linkerbell.campusmarket.android.presentation.common.view.DialogScreen
 import kr.linkerbell.campusmarket.android.presentation.common.view.image.PostImage
@@ -99,18 +100,18 @@ fun TradeInfoScreen(
             TradeInfoTopBar(
                 isOwnerOfThisTrade = isOwnerOfThisTrade,
                 onNavigatePreviousScreenButton = { navController.safeNavigateUp() },
-                reportArticle = { }, //신고 페이지로
-                deleteArticle = {
+                onReportOptionClicked = { }, //TODO(신고 페이지로 이동)
+                onDeleteArticleOptionClicked = {
                     isDeleteConfirmButtonVisible = true
                 },
-                patchArticle = {
+                onPatchArticleOptionClicked = {
                     val newRoute = makeRoute(
                         route = TradePostConstant.ROUTE,
                         arguments = mapOf(
                             TradePostConstant.ROUTE_ARGUMENT_ITEM_ID to tradeInfo.itemId.toString()
                         )
                     )
-                    navController.navigate(newRoute)
+                    navController.safeNavigate(newRoute)
                 }
             )
         },
@@ -159,10 +160,10 @@ fun TradeInfoScreen(
                     isCancelable = true,
                     onConfirm = {
                         argument.intent(TradeInfoIntent.DeleteThisPost)
+                        navController.safeNavigateUp()
                     },
                     onDismissRequest = {
                         isDeleteConfirmButtonVisible = false
-                        navController.safeNavigateUp()
                     }
                 )
             } else {
@@ -192,9 +193,9 @@ fun TradeInfoScreen(
 private fun TradeInfoTopBar(
     isOwnerOfThisTrade: Boolean,
     onNavigatePreviousScreenButton: () -> Unit,
-    reportArticle: () -> Unit,
-    patchArticle: () -> Unit,
-    deleteArticle: () -> Unit,
+    onReportOptionClicked: () -> Unit,
+    onPatchArticleOptionClicked: () -> Unit,
+    onDeleteArticleOptionClicked: () -> Unit,
 ) {
     var isDropDownExpanded by remember { mutableStateOf(false) }
 
@@ -256,15 +257,15 @@ private fun TradeInfoTopBar(
                             isDropDownExpanded = false
                             when (option) {
                                 "신고" -> {
-                                    reportArticle()
+                                    onReportOptionClicked()
                                 }
 
                                 "삭제" -> {
-                                    deleteArticle()
+                                    onDeleteArticleOptionClicked()
                                 }
 
                                 "수정" -> {
-                                    patchArticle()
+                                    onPatchArticleOptionClicked()
                                 }
                             }
                         }
@@ -288,10 +289,12 @@ private fun TradeInfoImageViewer(thumbUrl: String, imageUrls: List<String>) {
             .fillMaxWidth()
             .heightIn(min = 200.dp)
     ) { page ->
-        PostImage(
-            data = thumbnailAndImage[page],
-            modifier = Modifier.clip(shape = RoundedCornerShape(0))
-        )
+        thumbnailAndImage.getOrNull(page).let {
+            PostImage(
+                data = thumbnailAndImage[page],
+                modifier = Modifier.clip(shape = RoundedCornerShape(0))
+            )
+        }
     }
 }
 

--- a/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/trade/info/TradeInfoScreen.kt
+++ b/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/trade/info/TradeInfoScreen.kt
@@ -55,7 +55,6 @@ import kr.linkerbell.campusmarket.android.presentation.R
 import kr.linkerbell.campusmarket.android.presentation.common.theme.Black
 import kr.linkerbell.campusmarket.android.presentation.common.theme.Blue400
 import kr.linkerbell.campusmarket.android.presentation.common.theme.BlueGray200
-import kr.linkerbell.campusmarket.android.presentation.common.theme.BlueGray50
 import kr.linkerbell.campusmarket.android.presentation.common.theme.Body1
 import kr.linkerbell.campusmarket.android.presentation.common.theme.Headline2
 import kr.linkerbell.campusmarket.android.presentation.common.theme.Headline3
@@ -90,7 +89,7 @@ fun TradeInfoScreen(
         topBar = {
             TradeInfoTopBar(
                 isOwnerOfThisTrade = isOwnerOfThisTrade,
-                onNavigatePreviousScreenButton = { navController.popBackStack() },
+                onNavigatePreviousScreenButton = { navController.safeNavigateUp() },
                 reportArticle = { }, //신고 페이지로
                 deleteArticle = {
                     isDeleteConfirmButtonVisible = true
@@ -182,7 +181,7 @@ private fun TradeInfoTopBar(
         modifier = Modifier
             .fillMaxWidth()
             .border(1.dp, Color.Gray)
-            .background(Color.Transparent)
+            .background(White)
             .height(56.dp),
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically
@@ -191,7 +190,7 @@ private fun TradeInfoTopBar(
             Icon(
                 painter = painterResource(id = R.drawable.ic_chevron_left),
                 contentDescription = "Navigate Up Button",
-                tint = BlueGray50,
+                tint = Black,
                 modifier = Modifier
                     .size(48.dp)
                     .clickable {
@@ -202,13 +201,13 @@ private fun TradeInfoTopBar(
             Text(
                 text = "상세 정보",
                 style = Headline2,
-                color = BlueGray50
+                color = Black
             )
         }
         Box {
             Icon(
                 imageVector = Icons.Default.MoreVert,
-                tint = BlueGray50,
+                tint = Black,
                 contentDescription = "More Option Button",
                 modifier = Modifier
                     .size(48.dp)

--- a/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/trade/info/TradeInfoViewModel.kt
+++ b/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/trade/info/TradeInfoViewModel.kt
@@ -52,7 +52,7 @@ class TradeInfoViewModel @Inject constructor(
     val userInfo: StateFlow<MyProfile> = _userInfo.asStateFlow()
 
     private val itemId: Long by lazy {
-        savedStateHandle.get<Long>("itemId") ?: -1L
+        savedStateHandle.get<Long>(TradeInfoConstant.ROUTE_ARGUMENT_ITEM_ID) ?: -1L
     }
 
     init {
@@ -70,16 +70,13 @@ class TradeInfoViewModel @Inject constructor(
                 _state.value = TradeInfoState.Init
                 _authorInfo.value = it
             }.onFailure { exception ->
-                _state.value = TradeInfoState.Init
                 when (exception) {
                     is ServerException -> {
                         _errorEvent.emit(ErrorEvent.InvalidRequest(exception))
-                        _event.emit(TradeInfoEvent.FailedToFetchData)
                     }
 
                     else -> {
                         _errorEvent.emit(ErrorEvent.UnavailableServer(exception))
-                        _event.emit(TradeInfoEvent.FailedToFetchData)
                     }
                 }
             }

--- a/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/trade/info/TradeInfoViewModel.kt
+++ b/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/trade/info/TradeInfoViewModel.kt
@@ -74,10 +74,12 @@ class TradeInfoViewModel @Inject constructor(
                 when (exception) {
                     is ServerException -> {
                         _errorEvent.emit(ErrorEvent.InvalidRequest(exception))
+                        _event.emit(TradeInfoEvent.FailedToFetchData)
                     }
 
                     else -> {
                         _errorEvent.emit(ErrorEvent.UnavailableServer(exception))
+                        _event.emit(TradeInfoEvent.FailedToFetchData)
                     }
                 }
             }

--- a/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/trade/info/TradeInfoViewModel.kt
+++ b/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/trade/info/TradeInfoViewModel.kt
@@ -1,0 +1,128 @@
+package kr.linkerbell.campusmarket.android.presentation.ui.main.home.trade.info
+
+import androidx.lifecycle.SavedStateHandle
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kr.linkerbell.campusmarket.android.common.util.coroutine.event.EventFlow
+import kr.linkerbell.campusmarket.android.common.util.coroutine.event.MutableEventFlow
+import kr.linkerbell.campusmarket.android.common.util.coroutine.event.asEventFlow
+import kr.linkerbell.campusmarket.android.domain.model.feature.trade.TradeInfo
+import kr.linkerbell.campusmarket.android.domain.model.nonfeature.user.MyProfile
+import kr.linkerbell.campusmarket.android.domain.model.nonfeature.user.UserProfile
+import kr.linkerbell.campusmarket.android.domain.usecase.feature.trade.DeleteLikedItemUseCase
+import kr.linkerbell.campusmarket.android.domain.usecase.feature.trade.DeleteTradeInfoUseCase
+import kr.linkerbell.campusmarket.android.domain.usecase.feature.trade.GetTradeInfoUseCase
+import kr.linkerbell.campusmarket.android.domain.usecase.feature.trade.PostLikedItemUseCase
+import kr.linkerbell.campusmarket.android.domain.usecase.nonfeature.user.GetMyProfileUseCase
+import kr.linkerbell.campusmarket.android.domain.usecase.nonfeature.user.GetUserProfileUseCase
+import kr.linkerbell.campusmarket.android.presentation.common.base.BaseViewModel
+
+@HiltViewModel
+class TradeInfoViewModel @Inject constructor(
+    private val savedStateHandle: SavedStateHandle,
+    private val getTradeInfoUseCase: GetTradeInfoUseCase,
+    private val getUserProfileUseCase: GetUserProfileUseCase,
+    private val postLikedItemUseCase: PostLikedItemUseCase,
+    private val deleteLikedItemUseCase: DeleteLikedItemUseCase,
+    private val deleteTradeInfoUseCase: DeleteTradeInfoUseCase,
+    private val getMyProfileUseCase: GetMyProfileUseCase
+) : BaseViewModel() {
+
+    private val _state: MutableStateFlow<TradeInfoState> = MutableStateFlow(TradeInfoState.Init)
+    val state: StateFlow<TradeInfoState> = _state.asStateFlow()
+
+    private val _event: MutableEventFlow<TradeInfoEvent> = MutableEventFlow()
+    val event: EventFlow<TradeInfoEvent> = _event.asEventFlow()
+
+    private val _tradeInfo: MutableStateFlow<TradeInfo> = MutableStateFlow(TradeInfo.empty)
+    val tradeInfo: StateFlow<TradeInfo> = _tradeInfo.asStateFlow()
+
+    private val _authorInfo: MutableStateFlow<UserProfile> = MutableStateFlow(UserProfile.empty)
+    val authorInfo: StateFlow<UserProfile> = _authorInfo.asStateFlow()
+
+    private val _userInfo: MutableStateFlow<MyProfile> = MutableStateFlow(MyProfile.empty)
+    val userInfo: StateFlow<MyProfile> = _userInfo.asStateFlow()
+
+    private val itemId = savedStateHandle["itemId"] ?: "-1"
+
+    init {
+        launch {
+            getTradeInfo(itemId.toLong())
+            getUserInfo(_tradeInfo.value.userId)
+            getMyInfo()
+        }
+    }
+
+    fun onIntent(intent: TradeInfoIntent) {
+        when (intent) {
+            is TradeInfoIntent.LikeButtonClicked -> {
+                changeLikeStatus()
+            }
+
+            is TradeInfoIntent.DeleteThisPost -> {
+                deleteTradeInfo()
+            }
+        }
+    }
+
+    private suspend fun getMyInfo() {
+        _state.value = TradeInfoState.Loading
+        getMyProfileUseCase().onSuccess {
+            _state.value = TradeInfoState.Init
+            _userInfo.value = it
+        }.onFailure {
+            _state.value = TradeInfoState.Init
+        }
+    }
+
+    private suspend fun getTradeInfo(itemId: Long) {
+        _state.value = TradeInfoState.Loading
+        getTradeInfoUseCase(itemId).onSuccess {
+            _state.value = TradeInfoState.Init
+            _tradeInfo.value = it
+        }.onFailure {
+            _state.value = TradeInfoState.Init
+        }
+    }
+
+    private suspend fun getUserInfo(id: Long) {
+        _state.value = TradeInfoState.Loading
+
+        getUserProfileUseCase(id).onSuccess {
+            _state.value = TradeInfoState.Init
+            _authorInfo.value = it
+        }.onFailure {
+            _state.value = TradeInfoState.Init
+        }
+    }
+
+    private fun changeLikeStatus() {
+        if (_tradeInfo.value.isLiked) {
+            _tradeInfo.value = _tradeInfo.value.copy(
+                isLiked = !_tradeInfo.value.isLiked,
+                likeCount = _tradeInfo.value.likeCount - 1
+            )
+            launch { deleteLikedItemUseCase(_tradeInfo.value.itemId) }
+        } else {
+            _tradeInfo.value = _tradeInfo.value.copy(
+                isLiked = !_tradeInfo.value.isLiked,
+                likeCount = _tradeInfo.value.likeCount + 1
+            )
+            launch { postLikedItemUseCase(_tradeInfo.value.itemId) }
+        }
+    }
+
+    private fun deleteTradeInfo() {
+        _state.value = TradeInfoState.Loading
+        launch {
+            deleteTradeInfoUseCase(_tradeInfo.value.itemId).onSuccess {
+                _state.value = TradeInfoState.Init
+            }.onFailure {
+                _state.value = TradeInfoState.Init
+            }
+        }
+    }
+}

--- a/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/trade/post/TradePostArgument.kt
+++ b/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/trade/post/TradePostArgument.kt
@@ -19,7 +19,9 @@ sealed interface TradePostState {
     data object Loading : TradePostState
 }
 
-sealed interface TradePostEvent
+sealed interface TradePostEvent{
+    data class NavigateToTrade(val tradeId: Long) : TradePostEvent
+}
 
 sealed interface TradePostIntent {
     data class PostOrPatchTrade(
@@ -27,6 +29,7 @@ sealed interface TradePostIntent {
         val description: String,
         val price: Int,
         val category: String,
-        val imageList: List<GalleryImage>?
+        val originalImageList: List<String>,
+        val imageList: List<GalleryImage>
     ) : TradePostIntent
 }

--- a/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/trade/post/TradePostArgument.kt
+++ b/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/trade/post/TradePostArgument.kt
@@ -22,7 +22,7 @@ sealed interface TradePostState {
 sealed interface TradePostEvent
 
 sealed interface TradePostIntent {
-    data class PostNewTrade(
+    data class PostOrPatchTrade(
         val title: String,
         val description: String,
         val price: Int,

--- a/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/trade/post/TradePostArgument.kt
+++ b/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/trade/post/TradePostArgument.kt
@@ -1,9 +1,9 @@
 package kr.linkerbell.campusmarket.android.presentation.ui.main.home.trade.post
 
 import androidx.compose.runtime.Immutable
-import kotlin.coroutines.CoroutineContext
 import kr.linkerbell.campusmarket.android.common.util.coroutine.event.EventFlow
 import kr.linkerbell.campusmarket.android.presentation.model.gallery.GalleryImage
+import kotlin.coroutines.CoroutineContext
 
 @Immutable
 data class TradePostArgument(
@@ -19,8 +19,11 @@ sealed interface TradePostState {
     data object Loading : TradePostState
 }
 
-sealed interface TradePostEvent{
+sealed interface TradePostEvent {
     data class NavigateToTrade(val tradeId: Long) : TradePostEvent
+    data object FailedToPostOrPatch : TradePostEvent
+    data object FailedToFetchOriginalContents : TradePostEvent
+
 }
 
 sealed interface TradePostIntent {

--- a/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/trade/post/TradePostArgument.kt
+++ b/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/trade/post/TradePostArgument.kt
@@ -21,9 +21,7 @@ sealed interface TradePostState {
 
 sealed interface TradePostEvent {
     data class NavigateToTrade(val tradeId: Long) : TradePostEvent
-    data object FailedToPostOrPatch : TradePostEvent
-    data object FailedToFetchOriginalContents : TradePostEvent
-
+    data object FetchOriginalContents: TradePostEvent
 }
 
 sealed interface TradePostIntent {

--- a/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/trade/post/TradePostConstant.kt
+++ b/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/trade/post/TradePostConstant.kt
@@ -4,4 +4,7 @@ import kr.linkerbell.campusmarket.android.presentation.ui.main.home.trade.TradeC
 
 object TradePostConstant {
     const val ROUTE: String = "${TradeConstant.ROUTE}/post"
+    const val ROUTE_ARGUMENT_ITEM_ID = "itemId"
+
+    const val ROUTE_STRUCTURE = "${ROUTE}?$ROUTE_ARGUMENT_ITEM_ID={$ROUTE_ARGUMENT_ITEM_ID}"
 }

--- a/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/trade/post/TradePostData.kt
+++ b/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/trade/post/TradePostData.kt
@@ -1,11 +1,10 @@
 package kr.linkerbell.campusmarket.android.presentation.ui.main.home.trade.post
 
 import androidx.compose.runtime.Immutable
-import kr.linkerbell.campusmarket.android.domain.model.feature.trade.CategoryList
 import kr.linkerbell.campusmarket.android.domain.model.feature.trade.TradeContents
 
 @Immutable
 data class TradePostData(
-    val categoryList: List<String> = CategoryList.empty.categoryList,
-    val originalTradeContents : TradeContents
+    val categoryList: List<String>,
+    val originalTradeContents: TradeContents
 )

--- a/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/trade/post/TradePostData.kt
+++ b/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/trade/post/TradePostData.kt
@@ -2,8 +2,10 @@ package kr.linkerbell.campusmarket.android.presentation.ui.main.home.trade.post
 
 import androidx.compose.runtime.Immutable
 import kr.linkerbell.campusmarket.android.domain.model.feature.trade.CategoryList
+import kr.linkerbell.campusmarket.android.domain.model.feature.trade.TradeContents
 
 @Immutable
 data class TradePostData(
-    val categoryList: List<String> = CategoryList.empty.categoryList
+    val categoryList: List<String> = CategoryList.empty.categoryList,
+    val originalTradeContents : TradeContents
 )

--- a/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/trade/post/TradePostDestination.kt
+++ b/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/trade/post/TradePostDestination.kt
@@ -36,13 +36,14 @@ fun NavGraphBuilder.tradePostDestination(
             )
         }
 
-        val data: TradePostData = let {
+        val data: TradePostData = Unit.let {
             val categoryList = viewModel.categoryList.value
-            val originalTradePostInfo = viewModel.originalTradeContents.value
+            val originalTradePostInfo = viewModel.originalTradeContents.collectAsStateWithLifecycle(
+            )
 
             TradePostData(
                 categoryList = categoryList,
-                originalTradeContents = originalTradePostInfo
+                originalTradeContents = originalTradePostInfo.value
             )
         }
 

--- a/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/trade/post/TradePostDestination.kt
+++ b/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/trade/post/TradePostDestination.kt
@@ -5,14 +5,55 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavType
 import androidx.navigation.compose.composable
+import androidx.navigation.navArgument
+import kr.linkerbell.campusmarket.android.domain.model.feature.trade.TradeContents
 import kr.linkerbell.campusmarket.android.presentation.common.util.compose.ErrorObserver
 
 fun NavGraphBuilder.tradePostDestination(
     navController: NavController
 ) {
     composable(
-        route = TradePostConstant.ROUTE,
+        route = TradePostConstant.ROUTE_STRUCTURE,
+        arguments = listOf(
+            navArgument("itemId") { type = NavType.StringType; defaultValue = "0" },
+        )
+    ) {
+        val viewModel: TradePostViewModel = hiltViewModel()
+
+        val argument: TradePostArgument = let {
+            val state by viewModel.state.collectAsStateWithLifecycle()
+
+            TradePostArgument(
+                state = state,
+                event = viewModel.event,
+                intent = viewModel::onIntent,
+                logEvent = viewModel::logEvent,
+                coroutineContext = viewModel.coroutineContext
+            )
+        }
+
+        val data: TradePostData = let {
+            val categoryList = viewModel.categoryList.value
+            val originalTradePostInfo = viewModel.originalTradeContents.value
+
+            TradePostData(
+                categoryList = categoryList,
+                originalTradeContents = originalTradePostInfo
+            )
+        }
+
+        ErrorObserver(viewModel)
+        TradePostScreen(
+            navController = navController,
+            argument = argument,
+            data = data
+        )
+    }
+
+    composable(
+        route = TradePostConstant.ROUTE
     ) {
         val viewModel: TradePostViewModel = hiltViewModel()
 
@@ -32,7 +73,8 @@ fun NavGraphBuilder.tradePostDestination(
             val categoryList = viewModel.categoryList.value
 
             TradePostData(
-                categoryList = categoryList
+                categoryList = categoryList,
+                originalTradeContents = TradeContents.empty
             )
         }
 

--- a/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/trade/post/TradePostDestination.kt
+++ b/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/trade/post/TradePostDestination.kt
@@ -16,7 +16,7 @@ fun NavGraphBuilder.tradePostDestination(
     composable(
         route = TradePostConstant.ROUTE_STRUCTURE,
         arguments = listOf(
-            navArgument("itemId") {
+            navArgument(TradePostConstant.ROUTE_ARGUMENT_ITEM_ID) {
                 type = NavType.LongType
                 defaultValue = -1L
             },
@@ -37,13 +37,12 @@ fun NavGraphBuilder.tradePostDestination(
         }
 
         val data: TradePostData = Unit.let {
-            val categoryList = viewModel.categoryList.value
-            val originalTradePostInfo = viewModel.originalTradeContents.collectAsStateWithLifecycle(
-            )
+            val categoryList by viewModel.categoryList.collectAsStateWithLifecycle()
+            val originalTradePostInfo by viewModel.originalTradeContents.collectAsStateWithLifecycle()
 
             TradePostData(
                 categoryList = categoryList,
-                originalTradeContents = originalTradePostInfo.value
+                originalTradeContents = originalTradePostInfo
             )
         }
 

--- a/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/trade/post/TradePostDestination.kt
+++ b/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/trade/post/TradePostDestination.kt
@@ -8,7 +8,6 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavType
 import androidx.navigation.compose.composable
 import androidx.navigation.navArgument
-import kr.linkerbell.campusmarket.android.domain.model.feature.trade.TradeContents
 import kr.linkerbell.campusmarket.android.presentation.common.util.compose.ErrorObserver
 
 fun NavGraphBuilder.tradePostDestination(
@@ -17,7 +16,10 @@ fun NavGraphBuilder.tradePostDestination(
     composable(
         route = TradePostConstant.ROUTE_STRUCTURE,
         arguments = listOf(
-            navArgument("itemId") { type = NavType.StringType; defaultValue = "0" },
+            navArgument("itemId") {
+                type = NavType.LongType
+                defaultValue = -1L
+            },
         )
     ) {
         val viewModel: TradePostViewModel = hiltViewModel()
@@ -41,40 +43,6 @@ fun NavGraphBuilder.tradePostDestination(
             TradePostData(
                 categoryList = categoryList,
                 originalTradeContents = originalTradePostInfo
-            )
-        }
-
-        ErrorObserver(viewModel)
-        TradePostScreen(
-            navController = navController,
-            argument = argument,
-            data = data
-        )
-    }
-
-    composable(
-        route = TradePostConstant.ROUTE
-    ) {
-        val viewModel: TradePostViewModel = hiltViewModel()
-
-        val argument: TradePostArgument = let {
-            val state by viewModel.state.collectAsStateWithLifecycle()
-
-            TradePostArgument(
-                state = state,
-                event = viewModel.event,
-                intent = viewModel::onIntent,
-                logEvent = viewModel::logEvent,
-                coroutineContext = viewModel.coroutineContext
-            )
-        }
-
-        val data: TradePostData = let {
-            val categoryList = viewModel.categoryList.value
-
-            TradePostData(
-                categoryList = categoryList,
-                originalTradeContents = TradeContents.empty
             )
         }
 

--- a/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/trade/post/TradePostScreen.kt
+++ b/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/trade/post/TradePostScreen.kt
@@ -89,12 +89,15 @@ fun TradePostScreen(
     val scope = rememberCoroutineScope() + coroutineContext
 
     val originalContents = data.originalTradeContents
-    var title by remember { mutableStateOf("") }
-    var price by remember { mutableStateOf("0") }
-    var category by remember { mutableStateOf("OTHER") }
-    var description by remember { mutableStateOf("") }
 
-    var originalImageList: List<String> by remember { mutableStateOf(emptyList()) }
+    var title by remember { mutableStateOf(originalContents.title) }
+    var price by remember { mutableStateOf(originalContents.price.toString()) }
+    var category by remember { mutableStateOf(originalContents.category) }
+    var description by remember { mutableStateOf(originalContents.description) }
+    var originalImageList: List<String> by remember {
+        mutableStateOf(
+            (listOf(originalContents.thumbnail) + originalContents.images).filter { it.isNotBlank() })
+    }
     var imageList: List<GalleryImage> by remember { mutableStateOf(emptyList()) }
     var hasThumbnails by remember { mutableStateOf(false) }
 

--- a/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/trade/post/TradePostScreen.kt
+++ b/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/trade/post/TradePostScreen.kt
@@ -29,9 +29,9 @@ import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -90,14 +90,15 @@ fun TradePostScreen(
 
     val originalContents = data.originalTradeContents
 
-    var tradeId by remember { mutableStateOf(-1L) }
+    var tradeId by remember { mutableLongStateOf(-1L) }
     var title by remember { mutableStateOf(originalContents.title) }
     var price by remember { mutableStateOf(originalContents.price.toString()) }
     var category by remember { mutableStateOf(originalContents.category) }
     var description by remember { mutableStateOf(originalContents.description) }
     var originalImageList: List<String> by remember {
         mutableStateOf(
-            (listOf(originalContents.thumbnail) + originalContents.images).filter { it.isNotBlank() })
+            (listOf(originalContents.thumbnail) + originalContents.images).filter { it.isNotBlank() }
+        )
     }
     var imageList: List<GalleryImage> by remember { mutableStateOf(emptyList()) }
     var hasThumbnails by remember { mutableStateOf(false) }
@@ -105,20 +106,9 @@ fun TradePostScreen(
     var isGalleryShowing by remember { mutableStateOf(false) }
     var isValidationBottomSheetVisible by remember { mutableStateOf(false) }
     var isSuccessDialogVisible by remember { mutableStateOf(false) }
-    var isFailedToFetchErrorDialogVisible by remember { mutableStateOf(false) }
-    var isFailedToPostOrPatchDialogVisible by remember { mutableStateOf(false) }
 
     var isValidContents by remember { mutableStateOf(true) }
     var bottomSheetContent by remember { mutableStateOf("Bottom Sheet Content") }
-
-    LaunchedEffect(originalContents) {
-        title = originalContents.title
-        price = originalContents.price.toString()
-        category = originalContents.category
-        description = originalContents.description
-        originalImageList =
-            (listOf(originalContents.thumbnail) + originalContents.images).filter { it.isNotBlank() }
-    }
 
     val validateContent = {
         when {
@@ -247,11 +237,10 @@ fun TradePostScreen(
             selectedImageList = imageList,
             onDismissRequest = { isGalleryShowing = false },
             onResult = { addedImage ->
-                imageList = emptyList()
-                imageList += addedImage
+                imageList = addedImage
             },
             minSelectCount = 1,
-            maxSelectCount = 5 - originalImageList.size - imageList.size
+            maxSelectCount = 5 - originalImageList.size
         )
     }
 
@@ -269,33 +258,21 @@ fun TradePostScreen(
         )
     }
 
-    if (isFailedToFetchErrorDialogVisible) {
-        FailedToFetchOriginalContentsDialog(
-            onDismissRequest = { isFailedToFetchErrorDialogVisible = false }
-        )
-    }
-
-    if (isFailedToPostOrPatchDialogVisible) {
-        FailedToPostOrPatchDialog(
-            onDismissRequest = { isFailedToPostOrPatchDialogVisible = false }
-        )
-    }
-
     LaunchedEffectWithLifecycle(event, coroutineContext) {
         event.eventObserve { event ->
             when (event) {
                 is TradePostEvent.NavigateToTrade -> {
                     tradeId = event.tradeId
                     isSuccessDialogVisible = true
-                    //navigateToTrade(itemId = event.tradeId)
                 }
 
-                is TradePostEvent.FailedToFetchOriginalContents -> {
-                    isFailedToFetchErrorDialogVisible = true
-                }
-
-                is TradePostEvent.FailedToPostOrPatch -> {
-                    isFailedToPostOrPatchDialogVisible = true
+                is TradePostEvent.FetchOriginalContents -> {
+                    title = originalContents.title
+                    price = originalContents.price.toString()
+                    category = originalContents.category
+                    description = originalContents.description
+                    originalImageList =
+                        (listOf(originalContents.thumbnail) + originalContents.images).filter { it.isNotBlank() }
                 }
             }
         }
@@ -636,30 +613,6 @@ private fun TradePostScreenPostButton(onPostButtonClicked: () -> Unit) {
             color = Color.White
         )
     }
-}
-
-@Composable
-private fun FailedToFetchOriginalContentsDialog(
-    onDismissRequest: () -> Unit
-) {
-    DialogScreen(
-        title = "오류 발생!",
-        message = "기존 게시글 정보를 불러오지 못했습니다.",
-        isCancelable = false,
-        onDismissRequest = { onDismissRequest() }
-    )
-}
-
-@Composable
-private fun FailedToPostOrPatchDialog(
-    onDismissRequest: () -> Unit
-) {
-    DialogScreen(
-        title = "오류 발생!",
-        message = "게시글 등록에 실패했습니다.\n잠시 후 다시 시도해주세요.",
-        isCancelable = false,
-        onDismissRequest = { onDismissRequest() }
-    )
 }
 
 @Composable

--- a/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/trade/post/TradePostScreen.kt
+++ b/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/trade/post/TradePostScreen.kt
@@ -56,6 +56,7 @@ import kr.linkerbell.campusmarket.android.presentation.common.theme.Blue400
 import kr.linkerbell.campusmarket.android.presentation.common.theme.Body0
 import kr.linkerbell.campusmarket.android.presentation.common.theme.Body2
 import kr.linkerbell.campusmarket.android.presentation.common.theme.Gray200
+import kr.linkerbell.campusmarket.android.presentation.common.theme.Gray600
 import kr.linkerbell.campusmarket.android.presentation.common.theme.Headline2
 import kr.linkerbell.campusmarket.android.presentation.common.theme.Headline3
 import kr.linkerbell.campusmarket.android.presentation.common.theme.Indigo100
@@ -73,7 +74,6 @@ import kr.linkerbell.campusmarket.android.presentation.common.view.image.PostIma
 import kr.linkerbell.campusmarket.android.presentation.common.view.textfield.TypingTextField
 import kr.linkerbell.campusmarket.android.presentation.model.gallery.GalleryImage
 import kr.linkerbell.campusmarket.android.presentation.ui.main.common.gallery.GalleryScreen
-import kr.linkerbell.campusmarket.android.presentation.ui.main.home.trade.info.TradeInfoConstant
 import timber.log.Timber
 
 @Composable
@@ -182,7 +182,8 @@ fun TradePostScreen(
                             )
                             hasThumbnails = true
                         }
-                        Timber.tag("siri22").d("after render images -> $originalImageList\n $imageList")
+                        Timber.tag("siri22")
+                            .d("after render images -> $originalImageList\n $imageList")
                     }
                 }
                 TradePostScreenTradeInfo(
@@ -261,7 +262,8 @@ fun TradePostScreen(
             title = "등록되었습니다!",
             isCancelable = false,
             onConfirm = {
-                Timber.tag("siri22").d("isConfirmButtonVisible-> $originalImageList\nImageList : $imageList")
+                Timber.tag("siri22")
+                    .d("isConfirmButtonVisible-> $originalImageList\nImageList : $imageList")
                 argument.intent(
                     TradePostIntent.PostOrPatchTrade(
                         title = title,
@@ -485,33 +487,38 @@ private fun TradePostScreenTradeInfo(
             }
         }
         Column {
-            Text(
-                text = "상품 상세 정보",
-                style = Headline3,
-                modifier = Modifier.padding(bottom = 8.dp)
-            )
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                Text(
+                    text = "상품 상세 정보",
+                    style = Headline3,
+                    modifier = Modifier.padding(bottom = 8.dp)
+                )
+                Text(
+                    text = "모두 지우기",
+                    style = Body2,
+                    color = Gray600,
+                    modifier = Modifier
+                        .padding(top = 8.dp, end = 8.dp)
+                        .clickable {
+                            changeDescription("")
+                        }
+                )
+            }
             TypingTextField(
                 text = description,
                 onValueChange = { changeDescription(it) },
                 hintText = "상품 정보를 입력해주세요 (최대 1,000자)",
                 maxLines = 100,
                 maxTextLength = 1000,
-                trailingIconContent = {
-                    Icon(
-                        imageVector = Icons.Default.Clear,
-                        contentDescription = "Clear button",
-                        modifier = Modifier
-                            .size(20.dp)
-                            .clickable {
-                                changeDescription("")
-                            }
-                    )
-                },
                 modifier = Modifier
                     .fillMaxWidth()
                     .height(180.dp)
             )
         }
+
     }
 }
 

--- a/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/trade/search/result/TradeSearchResultData.kt
+++ b/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/trade/search/result/TradeSearchResultData.kt
@@ -2,11 +2,11 @@ package kr.linkerbell.campusmarket.android.presentation.ui.main.home.trade.searc
 
 import androidx.compose.runtime.Immutable
 import androidx.paging.compose.LazyPagingItems
-import kr.linkerbell.campusmarket.android.domain.model.feature.trade.Trade
+import kr.linkerbell.campusmarket.android.domain.model.feature.trade.SummarizedTrade
 
 @Immutable
 data class TradeSearchResultData(
-    val tradeList: LazyPagingItems<Trade>,
+    val summarizedTradeList: LazyPagingItems<SummarizedTrade>,
     val currentQuery: TradeSearchQuery,
     val categoryList: List<String>
 )

--- a/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/trade/search/result/TradeSearchResultDestination.kt
+++ b/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/trade/search/result/TradeSearchResultDestination.kt
@@ -39,12 +39,12 @@ fun NavGraphBuilder.tradeSearchResultDestination(
         }
 
         val data: TradeSearchResultData = let {
-            val tradeList = viewModel.tradeList.collectAsLazyPagingItems()
+            val tradeList = viewModel.summarizedTradeList.collectAsLazyPagingItems()
             val categoryList = viewModel.categoryList.value
             val currentQuery = viewModel.tradeSearchQuery.value
 
             TradeSearchResultData(
-                tradeList = tradeList,
+                summarizedTradeList = tradeList,
                 currentQuery = currentQuery,
                 categoryList = categoryList
             )

--- a/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/trade/search/result/TradeSearchResultScreen.kt
+++ b/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/trade/search/result/TradeSearchResultScreen.kt
@@ -59,6 +59,7 @@ import kr.linkerbell.campusmarket.android.domain.model.feature.trade.SummarizedT
 import kr.linkerbell.campusmarket.android.presentation.common.theme.Black
 import kr.linkerbell.campusmarket.android.presentation.common.theme.Blue100
 import kr.linkerbell.campusmarket.android.presentation.common.theme.Blue400
+import kr.linkerbell.campusmarket.android.presentation.common.theme.Body0
 import kr.linkerbell.campusmarket.android.presentation.common.theme.Body1
 import kr.linkerbell.campusmarket.android.presentation.common.theme.Body2
 import kr.linkerbell.campusmarket.android.presentation.common.theme.Caption2
@@ -127,12 +128,14 @@ fun TradeSearchResultScreen(
         HorizontalDivider(thickness = (0.4).dp, color = Black)
         if (data.summarizedTradeList.itemSnapshotList.size == 0) {
             Row(
-                modifier = Modifier.padding(16.dp),
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(16.dp),
                 horizontalArrangement = Arrangement.Center
             ) {
                 Text(
                     text = "표시할 항목이 없습니다.",
-                    style = Headline3,
+                    style = Body0,
                     color = Gray,
                     modifier = Modifier.padding(start = 16.dp)
                 )

--- a/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/trade/search/result/TradeSearchResultScreen.kt
+++ b/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/trade/search/result/TradeSearchResultScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
@@ -25,6 +26,7 @@ import androidx.compose.material.icons.filled.Notifications
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -39,6 +41,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Color.Companion.Gray
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
@@ -53,6 +56,7 @@ import kotlinx.coroutines.plus
 import kr.linkerbell.campusmarket.android.common.util.coroutine.event.MutableEventFlow
 import kr.linkerbell.campusmarket.android.domain.model.feature.trade.CategoryList
 import kr.linkerbell.campusmarket.android.domain.model.feature.trade.SummarizedTrade
+import kr.linkerbell.campusmarket.android.presentation.common.theme.Black
 import kr.linkerbell.campusmarket.android.presentation.common.theme.Blue100
 import kr.linkerbell.campusmarket.android.presentation.common.theme.Blue400
 import kr.linkerbell.campusmarket.android.presentation.common.theme.Body1
@@ -62,7 +66,6 @@ import kr.linkerbell.campusmarket.android.presentation.common.theme.Gray50
 import kr.linkerbell.campusmarket.android.presentation.common.theme.Headline3
 import kr.linkerbell.campusmarket.android.presentation.common.theme.Indigo50
 import kr.linkerbell.campusmarket.android.presentation.common.util.compose.makeRoute
-import kr.linkerbell.campusmarket.android.presentation.common.util.compose.safeNavigate
 import kr.linkerbell.campusmarket.android.presentation.common.view.image.PostImage
 import kr.linkerbell.campusmarket.android.presentation.common.view.textfield.TypingTextField
 import kr.linkerbell.campusmarket.android.presentation.ui.main.home.trade.info.TradeInfoConstant
@@ -120,27 +123,44 @@ fun TradeSearchResultScreen(
                 )
             }
         }
+
+        HorizontalDivider(thickness = (0.4).dp, color = Black)
+        if (data.summarizedTradeList.itemSnapshotList.size == 0) {
+            Row(
+                modifier = Modifier.padding(16.dp),
+                horizontalArrangement = Arrangement.Center
+            ) {
+                Text(
+                    text = "표시할 항목이 없습니다.",
+                    style = Headline3,
+                    color = Gray,
+                    modifier = Modifier.padding(start = 16.dp)
+                )
+            }
+        }
         LazyColumn(
+            modifier = Modifier.weight(1f),
             contentPadding = PaddingValues(vertical = 16.dp, horizontal = 20.dp)
         ) {
-            items(
-                count = data.summarizedTradeList.itemCount,
-                key = { index -> data.summarizedTradeList[index]?.itemId ?: -1 }
-            ) { index ->
-                val trade = data.summarizedTradeList[index] ?: return@items
-                TradeSearchResultItemCard(
-                    item = trade,
-                    onItemCardClicked = {
-                        val tradeInfoRoute = makeRoute(
-                            route = TradeInfoConstant.ROUTE,
-                            arguments = mapOf(
-                                TradeInfoConstant.ROUTE_ARGUMENT_ITEM_ID to trade.itemId.toString()
+            itemsIndexed(
+                items = data.summarizedTradeList.itemSnapshotList,
+                key = { _, item -> item?.itemId ?: -1 }
+            ) { _, trade ->
+                trade?.let {
+                    TradeSearchResultItemCard(
+                        item = it,
+                        onItemCardClicked = {
+                            val tradeInfoRoute = makeRoute(
+                                route = TradeInfoConstant.ROUTE,
+                                arguments = mapOf(
+                                    TradeInfoConstant.ROUTE_ARGUMENT_ITEM_ID to trade.itemId.toString()
+                                )
                             )
-                        )
-                        navController.safeNavigate(tradeInfoRoute)
-                    }
-                )
-                Spacer(modifier = Modifier.height(8.dp))
+                            navController.navigate(tradeInfoRoute)
+                        }
+                    )
+                    Spacer(modifier = Modifier.height(8.dp))
+                }
             }
         }
     }

--- a/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/trade/search/result/TradeSearchResultScreen.kt
+++ b/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/trade/search/result/TradeSearchResultScreen.kt
@@ -62,11 +62,11 @@ import kr.linkerbell.campusmarket.android.presentation.common.theme.Gray50
 import kr.linkerbell.campusmarket.android.presentation.common.theme.Headline3
 import kr.linkerbell.campusmarket.android.presentation.common.theme.Indigo50
 import kr.linkerbell.campusmarket.android.presentation.common.util.compose.makeRoute
+import kr.linkerbell.campusmarket.android.presentation.common.util.compose.safeNavigate
 import kr.linkerbell.campusmarket.android.presentation.common.view.image.PostImage
 import kr.linkerbell.campusmarket.android.presentation.common.view.textfield.TypingTextField
 import kr.linkerbell.campusmarket.android.presentation.ui.main.home.trade.info.TradeInfoConstant
 import kr.linkerbell.campusmarket.android.presentation.ui.main.home.trade.search.TradeSearchConstant
-import timber.log.Timber
 
 @Composable
 fun TradeSearchResultScreen(
@@ -130,15 +130,14 @@ fun TradeSearchResultScreen(
                 val trade = data.summarizedTradeList[index] ?: return@items
                 TradeSearchResultItemCard(
                     item = trade,
-                    navigateToTradeInfoScreen = {
+                    onItemCardClicked = {
                         val tradeInfoRoute = makeRoute(
                             route = TradeInfoConstant.ROUTE,
                             arguments = mapOf(
                                 TradeInfoConstant.ROUTE_ARGUMENT_ITEM_ID to trade.itemId.toString()
                             )
                         )
-                        Timber.tag("siri22").d("ROUTE : ${tradeInfoRoute}")
-                        navController.navigate(tradeInfoRoute)
+                        navController.safeNavigate(tradeInfoRoute)
                     }
                 )
                 Spacer(modifier = Modifier.height(8.dp))
@@ -149,7 +148,7 @@ fun TradeSearchResultScreen(
 
 @Composable
 private fun TradeSearchResultSearchBar(
-    currentQuery: String, navigateToTradeSearchScreen: () -> Unit
+    currentQuery: String, onSearchBarClicked: () -> Unit
 ) {
     Box(
         modifier = Modifier
@@ -181,7 +180,7 @@ private fun TradeSearchResultSearchBar(
                     .clip(RoundedCornerShape(5.dp))
                     .background(Gray50)
                     .clickable {
-                        navigateToTradeSearchScreen()
+                        onSearchBarClicked()
                     },
                 horizontalArrangement = Arrangement.SpaceBetween,
                 verticalAlignment = Alignment.CenterVertically
@@ -438,14 +437,14 @@ private fun TradeSearchResultSortOption(
 @Composable
 private fun TradeSearchResultItemCard(
     item: SummarizedTrade,
-    navigateToTradeInfoScreen: (Long) -> Unit
+    onItemCardClicked: (Long) -> Unit
 ) {
     Box(
         Modifier
             .shadow(4.dp)
             .clip(RoundedCornerShape(5.dp))
             .clickable {
-                navigateToTradeInfoScreen(item.itemId)
+                onItemCardClicked(item.itemId)
             }
     ) {
         Row(

--- a/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/trade/search/result/TradeSearchResultViewModel.kt
+++ b/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/trade/search/result/TradeSearchResultViewModel.kt
@@ -14,7 +14,7 @@ import kr.linkerbell.campusmarket.android.common.util.coroutine.event.EventFlow
 import kr.linkerbell.campusmarket.android.common.util.coroutine.event.MutableEventFlow
 import kr.linkerbell.campusmarket.android.common.util.coroutine.event.asEventFlow
 import kr.linkerbell.campusmarket.android.domain.model.feature.trade.CategoryList
-import kr.linkerbell.campusmarket.android.domain.model.feature.trade.Trade
+import kr.linkerbell.campusmarket.android.domain.model.feature.trade.SummarizedTrade
 import kr.linkerbell.campusmarket.android.domain.model.nonfeature.error.ServerException
 import kr.linkerbell.campusmarket.android.domain.usecase.feature.trade.GetCategoryListUseCase
 import kr.linkerbell.campusmarket.android.domain.usecase.feature.trade.SearchTradeListUseCase
@@ -35,9 +35,10 @@ class TradeSearchResultViewModel @Inject constructor(
     private val _event: MutableEventFlow<TradeSearchResultEvent> = MutableEventFlow()
     val event: EventFlow<TradeSearchResultEvent> = _event.asEventFlow()
 
-    private val _tradeList: MutableStateFlow<PagingData<Trade>> =
+    private val _summarizedTradeList: MutableStateFlow<PagingData<SummarizedTrade>> =
         MutableStateFlow(PagingData.empty())
-    val tradeList: StateFlow<PagingData<Trade>> = _tradeList.asStateFlow()
+    val summarizedTradeList: StateFlow<PagingData<SummarizedTrade>> =
+        _summarizedTradeList.asStateFlow()
 
     private val _categoryList: MutableStateFlow<List<String>> =
         MutableStateFlow(CategoryList.empty.categoryList)
@@ -98,7 +99,7 @@ class TradeSearchResultViewModel @Inject constructor(
                 }
             }.collect {
                 _state.value = TradeSearchResultState.Init
-                _tradeList.value = it
+                _summarizedTradeList.value = it
             }
     }
 

--- a/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/trade/search/result/TradeSearchResultViewModel.kt
+++ b/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/trade/search/result/TradeSearchResultViewModel.kt
@@ -54,7 +54,7 @@ class TradeSearchResultViewModel @Inject constructor(
             category = savedStateHandle["category"] ?: "",
             minPrice = savedStateHandle["minPrice"] ?: 0,
             maxPrice = savedStateHandle["maxPrice"] ?: Int.MAX_VALUE,
-            sorted = savedStateHandle["sorted"] ?: ""
+            sorted = savedStateHandle["sorted"] ?: "createdDate,desc"
         )
         launch {
             getCategoryList()


### PR DESCRIPTION
- Rebase & Feature (1)

## **설명**
- 상품 상세 정보 확인 가능 (TradeInfoScreen)
- 좋아요 +/- API 전송 및 화면 반영 (실제 서버에 반영되고 있는지는 확인해봐야 함)
- (...) 버튼으로 수정/삭제/신고(미구현) / 자신이 작성한 게시글이 아니면 "신고"만 나옴
- 게시글 수정 -> PATCH 기능 구현

- TODO (헬프 요청)
  - TradeInfoScreen : tradeInfo.itemId 기반으로 채팅 시작 로직
  - TradePostScreen : 게시글 Post/Patch 완료 시, Api로부터 쭉 내려오는 해당 itemId를 기반으로 상품 상세 화면으로 이동

## 참고
![image](https://github.com/user-attachments/assets/c1315146-7ad6-4503-a0d5-daa410acf6fb)
![image](https://github.com/user-attachments/assets/80d497f9-4f9f-4ab0-9539-b7f960c3b526)


## 체크리스트
- [x] : 빌드 테스트를 진행하셨나요?
- [x] : 실제 기기에서 테스트를 진행하셨나요?
