### PR TITLE
[CM-35.1] 다른 사용자 프로필 확인 UI & 로직 제작

### DIFF
--- a/data/src/main/kotlin/kr/linkerbell/campusmarket/android/data/di/RepositoryModule.kt
+++ b/data/src/main/kotlin/kr/linkerbell/campusmarket/android/data/di/RepositoryModule.kt
@@ -4,8 +4,8 @@ import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
-import javax.inject.Singleton
 import kr.linkerbell.campusmarket.android.data.repository.feature.chat.RealChatRepository
+import kr.linkerbell.campusmarket.android.data.repository.feature.mypage.RealMyPageRepository
 import kr.linkerbell.campusmarket.android.data.repository.feature.schedule.RealScheduleRepository
 import kr.linkerbell.campusmarket.android.data.repository.feature.trade.RealTradeRepository
 import kr.linkerbell.campusmarket.android.data.repository.nonfeature.authentication.RealAuthenticationRepository
@@ -15,6 +15,7 @@ import kr.linkerbell.campusmarket.android.data.repository.nonfeature.term.RealTe
 import kr.linkerbell.campusmarket.android.data.repository.nonfeature.tracking.RealTrackingRepository
 import kr.linkerbell.campusmarket.android.data.repository.nonfeature.user.RealUserRepository
 import kr.linkerbell.campusmarket.android.domain.repository.feature.ChatRepository
+import kr.linkerbell.campusmarket.android.domain.repository.feature.MyPageRepository
 import kr.linkerbell.campusmarket.android.domain.repository.feature.ScheduleRepository
 import kr.linkerbell.campusmarket.android.domain.repository.feature.TradeRepository
 import kr.linkerbell.campusmarket.android.domain.repository.nonfeature.AuthenticationRepository
@@ -23,6 +24,7 @@ import kr.linkerbell.campusmarket.android.domain.repository.nonfeature.TermRepos
 import kr.linkerbell.campusmarket.android.domain.repository.nonfeature.TokenRepository
 import kr.linkerbell.campusmarket.android.domain.repository.nonfeature.TrackingRepository
 import kr.linkerbell.campusmarket.android.domain.repository.nonfeature.UserRepository
+import javax.inject.Singleton
 
 @Module
 @InstallIn(SingletonComponent::class)
@@ -81,4 +83,10 @@ abstract class RepositoryModule {
     internal abstract fun bindsScheduleRepository(
         scheduleRepository: RealScheduleRepository
     ): ScheduleRepository
+
+    @Binds
+    @Singleton
+    internal abstract fun bindsMyPageRepository(
+        myPageRepository: RealMyPageRepository
+    ): MyPageRepository
 }

--- a/data/src/main/kotlin/kr/linkerbell/campusmarket/android/data/remote/network/api/feature/MyPageApi.kt
+++ b/data/src/main/kotlin/kr/linkerbell/campusmarket/android/data/remote/network/api/feature/MyPageApi.kt
@@ -1,0 +1,44 @@
+package kr.linkerbell.campusmarket.android.data.remote.network.api.feature
+
+import io.ktor.client.HttpClient
+import io.ktor.client.request.get
+import io.ktor.client.request.parameter
+import kr.linkerbell.campusmarket.android.data.remote.network.di.AuthHttpClient
+import kr.linkerbell.campusmarket.android.data.remote.network.environment.BaseUrlProvider
+import kr.linkerbell.campusmarket.android.data.remote.network.environment.ErrorMessageMapper
+import kr.linkerbell.campusmarket.android.data.remote.network.model.feature.mypage.RecentTradeRes
+import kr.linkerbell.campusmarket.android.data.remote.network.model.feature.mypage.UserReviewRes
+import kr.linkerbell.campusmarket.android.data.remote.network.util.convert
+import javax.inject.Inject
+
+class MyPageApi @Inject constructor(
+    @AuthHttpClient private val client: HttpClient,
+    private val baseUrlProvider: BaseUrlProvider,
+    private val errorMessageMapper: ErrorMessageMapper
+) {
+    private val baseUrl: String
+        get() = baseUrlProvider.get()
+
+    suspend fun getUserReviews(
+        userId: Long,
+        page: Int,
+        size: Int
+    ): Result<UserReviewRes> {
+        return client.get("$baseUrl/api/v1/users/$userId/reviews") {
+            parameter("page", page.toString())
+            parameter("size", size.toString())
+        }.convert(errorMessageMapper::map)
+    }
+
+    suspend fun getRecentTrade(
+        userId: Long,
+        page: Int,
+        size: Int,
+        type: String
+    ): Result<RecentTradeRes> {
+        return client.get("$baseUrl/api/v1/items/$userId/history?type=$type") {
+            parameter("page", page.toString())
+            parameter("size", size.toString())
+        }.convert(errorMessageMapper::map)
+    }
+}

--- a/data/src/main/kotlin/kr/linkerbell/campusmarket/android/data/remote/network/api/feature/TradeApi.kt
+++ b/data/src/main/kotlin/kr/linkerbell/campusmarket/android/data/remote/network/api/feature/TradeApi.kt
@@ -36,18 +36,18 @@ class TradeApi @Inject constructor(
         category: String,
         minPrice: Int,
         maxPrice: Int,
-        sorted: String,
-        pageNum: Int,
-        pageSize: Int
+        sort: String,
+        page: Int,
+        size: Int
     ): Result<SearchTradeListRes> {
         return client.get("$baseUrl/api/v1/items") {
             parameter("name", name)
             parameter("category", category)
             parameter("minPrice", minPrice.toString())
             parameter("maxPrice", maxPrice.toString())
-            parameter("sort", sorted)
-            parameter("page", pageNum.toString())
-            parameter("size", pageSize.toString())
+            parameter("sort", sort)
+            parameter("page", page.toString())
+            parameter("size", size.toString())
         }.convert(errorMessageMapper::map)
     }
 

--- a/data/src/main/kotlin/kr/linkerbell/campusmarket/android/data/remote/network/model/feature/mypage/RecentTradeRes.kt
+++ b/data/src/main/kotlin/kr/linkerbell/campusmarket/android/data/remote/network/model/feature/mypage/RecentTradeRes.kt
@@ -1,0 +1,47 @@
+package kr.linkerbell.campusmarket.android.data.remote.network.model.feature.mypage
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kr.linkerbell.campusmarket.android.data.remote.mapper.DataMapper
+import kr.linkerbell.campusmarket.android.domain.model.feature.mypage.RecentTrade
+import kr.linkerbell.campusmarket.android.domain.model.feature.mypage.UserReview
+
+@Serializable
+data class RecentTradeRes(
+    @SerialName("items")
+    val reviewList: List<RecentTradeItemRes>,
+    @SerialName("sort")
+    val sort: String,
+    @SerialName("currentPage")
+    val currentPage: Int,
+    @SerialName("size")
+    val size: Int,
+    @SerialName("hasPrevious")
+    val hasPrevious: Boolean,
+    @SerialName("hasNext")
+    val hasNext: Boolean,
+)
+
+@Serializable
+data class RecentTradeItemRes(
+    @SerialName("id")
+    val id: Long,
+    @SerialName("title")
+    val title: String,
+    @SerialName("price")
+    val price: Int,
+    @SerialName("thumbnail")
+    val thumbnail: String,
+    @SerialName("itemStatus")
+    val itemStatus: String
+) : DataMapper<RecentTrade> {
+    override fun toDomain(): RecentTrade {
+        return RecentTrade(
+            id = id,
+            title = title,
+            price = price,
+            thumbnail = thumbnail,
+            isSold = (itemStatus == "SOLDOUT")
+        )
+    }
+}

--- a/data/src/main/kotlin/kr/linkerbell/campusmarket/android/data/remote/network/model/feature/mypage/UserReviewRes.kt
+++ b/data/src/main/kotlin/kr/linkerbell/campusmarket/android/data/remote/network/model/feature/mypage/UserReviewRes.kt
@@ -1,0 +1,48 @@
+package kr.linkerbell.campusmarket.android.data.remote.network.model.feature.mypage
+
+import kotlinx.datetime.LocalDateTime
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kr.linkerbell.campusmarket.android.data.remote.mapper.DataMapper
+import kr.linkerbell.campusmarket.android.domain.model.feature.mypage.UserReview
+
+@Serializable
+data class UserReviewRes(
+    @SerialName("reviewList")
+    val reviewList: List<ReviewItemRes>,
+    @SerialName("currentPage")
+    val currentPage: Int,
+    @SerialName("size")
+    val size: Int,
+    @SerialName("hasPrevious")
+    val hasPrevious: Boolean,
+    @SerialName("hasNext")
+    val hasNext: Boolean,
+)
+
+@Serializable
+data class ReviewItemRes(
+    @SerialName("userId")
+    val userId: Long,
+    @SerialName("nickname")
+    val nickname: String,
+    @SerialName("profileImage")
+    val profileImage: String,
+    @SerialName("description")
+    val description: String,
+    @SerialName("rating")
+    val rating: Double,
+    @SerialName("createdAt")
+    val createdAt: LocalDateTime
+) : DataMapper<UserReview> {
+    override fun toDomain(): UserReview {
+        return UserReview(
+            userId = userId,
+            nickname = nickname,
+            profileImage = profileImage,
+            description = description,
+            rating = rating.toInt(),
+            createdAt = createdAt
+        )
+    }
+}

--- a/data/src/main/kotlin/kr/linkerbell/campusmarket/android/data/remote/network/model/feature/mypage/UserReviewRes.kt
+++ b/data/src/main/kotlin/kr/linkerbell/campusmarket/android/data/remote/network/model/feature/mypage/UserReviewRes.kt
@@ -31,7 +31,7 @@ data class ReviewItemRes(
     @SerialName("description")
     val description: String,
     @SerialName("rating")
-    val rating: Double,
+    val rating: Int,
     @SerialName("createdAt")
     val createdAt: LocalDateTime
 ) : DataMapper<UserReview> {
@@ -41,7 +41,7 @@ data class ReviewItemRes(
             nickname = nickname,
             profileImage = profileImage,
             description = description,
-            rating = rating.toInt(),
+            rating = rating,
             createdAt = createdAt
         )
     }

--- a/data/src/main/kotlin/kr/linkerbell/campusmarket/android/data/repository/feature/mypage/RealMyPageRepository.kt
+++ b/data/src/main/kotlin/kr/linkerbell/campusmarket/android/data/repository/feature/mypage/RealMyPageRepository.kt
@@ -1,0 +1,53 @@
+package kr.linkerbell.campusmarket.android.data.repository.feature.mypage
+
+import androidx.paging.Pager
+import androidx.paging.PagingConfig
+import androidx.paging.PagingData
+import kotlinx.coroutines.flow.Flow
+import kr.linkerbell.campusmarket.android.data.common.DEFAULT_PAGING_SIZE
+import kr.linkerbell.campusmarket.android.data.remote.network.api.feature.MyPageApi
+import kr.linkerbell.campusmarket.android.data.repository.feature.mypage.paging.RecentTradePagingSource
+import kr.linkerbell.campusmarket.android.data.repository.feature.mypage.paging.ReviewPagingSource
+import kr.linkerbell.campusmarket.android.domain.model.feature.mypage.RecentTrade
+import kr.linkerbell.campusmarket.android.domain.model.feature.mypage.UserReview
+import kr.linkerbell.campusmarket.android.domain.repository.feature.MyPageRepository
+import javax.inject.Inject
+
+class RealMyPageRepository @Inject constructor(
+    private val myPageApi: MyPageApi,
+) : MyPageRepository {
+
+    override suspend fun getUserReviews(userId: Long): Flow<PagingData<UserReview>> {
+        return Pager(
+            config = PagingConfig(
+                pageSize = DEFAULT_PAGING_SIZE,
+                enablePlaceholders = true
+            ),
+            pagingSourceFactory = {
+                ReviewPagingSource(
+                    myPageApi = myPageApi,
+                    userId = userId
+                )
+            },
+        ).flow
+    }
+
+    override suspend fun getRecentTrades(
+        userId: Long,
+        type: String
+    ): Flow<PagingData<RecentTrade>> {
+        return Pager(
+            config = PagingConfig(
+                pageSize = DEFAULT_PAGING_SIZE,
+                enablePlaceholders = true
+            ),
+            pagingSourceFactory = {
+                RecentTradePagingSource(
+                    myPageApi = myPageApi,
+                    userId = userId,
+                    type = type
+                )
+            },
+        ).flow
+    }
+}

--- a/data/src/main/kotlin/kr/linkerbell/campusmarket/android/data/repository/feature/mypage/paging/RecentTradePagingSource.kt
+++ b/data/src/main/kotlin/kr/linkerbell/campusmarket/android/data/repository/feature/mypage/paging/RecentTradePagingSource.kt
@@ -1,0 +1,44 @@
+package kr.linkerbell.campusmarket.android.data.repository.feature.mypage.paging
+
+import androidx.paging.PagingSource
+import androidx.paging.PagingState
+import kr.linkerbell.campusmarket.android.data.common.DEFAULT_PAGE_START
+import kr.linkerbell.campusmarket.android.data.remote.network.api.feature.MyPageApi
+import kr.linkerbell.campusmarket.android.domain.model.feature.mypage.RecentTrade
+
+class RecentTradePagingSource(
+    private val myPageApi: MyPageApi,
+    private val userId: Long,
+    private val type: String
+) : PagingSource<Int, RecentTrade>() {
+
+    override fun getRefreshKey(state: PagingState<Int, RecentTrade>): Int? {
+        return state.anchorPosition?.let { anchorPosition ->
+            state.closestPageToPosition(anchorPosition)?.prevKey?.plus(1)
+                ?: state.closestPageToPosition(anchorPosition)?.nextKey?.minus(1)
+        }
+    }
+
+    override suspend fun load(params: LoadParams<Int>): LoadResult<Int, RecentTrade> {
+        val pageNum = params.key ?: DEFAULT_PAGE_START
+        val pageSize = params.loadSize
+
+        return myPageApi.getRecentTrade(
+            userId = userId,
+            page = pageNum,
+            size = pageSize,
+            type = type
+        ).map { data ->
+            val nextPage = if (data.hasNext) pageNum + 1 else null
+            val previousPage = if (data.hasPrevious) pageNum - 1 else null
+
+            LoadResult.Page(
+                data = data.reviewList.map { it.toDomain() },
+                prevKey = previousPage,
+                nextKey = nextPage
+            )
+        }.getOrElse { exception ->
+            LoadResult.Error(exception)
+        }
+    }
+}

--- a/data/src/main/kotlin/kr/linkerbell/campusmarket/android/data/repository/feature/mypage/paging/ReviewPagingSource.kt
+++ b/data/src/main/kotlin/kr/linkerbell/campusmarket/android/data/repository/feature/mypage/paging/ReviewPagingSource.kt
@@ -1,0 +1,42 @@
+package kr.linkerbell.campusmarket.android.data.repository.feature.mypage.paging
+
+import androidx.paging.PagingSource
+import androidx.paging.PagingState
+import kr.linkerbell.campusmarket.android.data.common.DEFAULT_PAGE_START
+import kr.linkerbell.campusmarket.android.data.remote.network.api.feature.MyPageApi
+import kr.linkerbell.campusmarket.android.domain.model.feature.mypage.UserReview
+
+class ReviewPagingSource(
+    private val myPageApi: MyPageApi,
+    private val userId: Long
+) : PagingSource<Int, UserReview>() {
+
+    override fun getRefreshKey(state: PagingState<Int, UserReview>): Int? {
+        return state.anchorPosition?.let { anchorPosition ->
+            state.closestPageToPosition(anchorPosition)?.prevKey?.plus(1)
+                ?: state.closestPageToPosition(anchorPosition)?.nextKey?.minus(1)
+        }
+    }
+
+    override suspend fun load(params: LoadParams<Int>): LoadResult<Int, UserReview> {
+        val pageNum = params.key ?: DEFAULT_PAGE_START
+        val pageSize = params.loadSize
+
+        return myPageApi.getUserReviews(
+            userId = userId,
+            page = pageNum,
+            size = pageSize
+        ).map { data ->
+            val nextPage = if (data.hasNext) pageNum + 1 else null
+            val previousPage = if (data.hasPrevious) pageNum - 1 else null
+
+            LoadResult.Page(
+                data = data.reviewList.map { it.toDomain() },
+                prevKey = previousPage,
+                nextKey = nextPage
+            )
+        }.getOrElse { exception ->
+            LoadResult.Error(exception)
+        }
+    }
+}

--- a/data/src/main/kotlin/kr/linkerbell/campusmarket/android/data/repository/feature/trade/RealTradeRepository.kt
+++ b/data/src/main/kotlin/kr/linkerbell/campusmarket/android/data/repository/feature/trade/RealTradeRepository.kt
@@ -12,6 +12,7 @@ import kr.linkerbell.campusmarket.android.data.remote.local.database.searchhisto
 import kr.linkerbell.campusmarket.android.data.remote.network.api.feature.TradeApi
 import kr.linkerbell.campusmarket.android.data.remote.network.util.toDomain
 import kr.linkerbell.campusmarket.android.data.repository.feature.trade.paging.SearchTradePagingSource
+import kr.linkerbell.campusmarket.android.domain.model.feature.mypage.UserReview
 import kr.linkerbell.campusmarket.android.domain.model.feature.trade.CategoryList
 import kr.linkerbell.campusmarket.android.domain.model.feature.trade.DeletedLikedItemInfo
 import kr.linkerbell.campusmarket.android.domain.model.feature.trade.LikedItemInfo
@@ -134,4 +135,5 @@ class RealTradeRepository @Inject constructor(
             rating
         )
     }
+
 }

--- a/data/src/main/kotlin/kr/linkerbell/campusmarket/android/data/repository/feature/trade/RealTradeRepository.kt
+++ b/data/src/main/kotlin/kr/linkerbell/campusmarket/android/data/repository/feature/trade/RealTradeRepository.kt
@@ -3,7 +3,6 @@ package kr.linkerbell.campusmarket.android.data.repository.feature.trade
 import androidx.paging.Pager
 import androidx.paging.PagingConfig
 import androidx.paging.PagingData
-import javax.inject.Inject
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import kr.linkerbell.campusmarket.android.data.common.DEFAULT_PAGING_SIZE
@@ -12,7 +11,6 @@ import kr.linkerbell.campusmarket.android.data.remote.local.database.searchhisto
 import kr.linkerbell.campusmarket.android.data.remote.network.api.feature.TradeApi
 import kr.linkerbell.campusmarket.android.data.remote.network.util.toDomain
 import kr.linkerbell.campusmarket.android.data.repository.feature.trade.paging.SearchTradePagingSource
-import kr.linkerbell.campusmarket.android.domain.model.feature.mypage.UserReview
 import kr.linkerbell.campusmarket.android.domain.model.feature.trade.CategoryList
 import kr.linkerbell.campusmarket.android.domain.model.feature.trade.DeletedLikedItemInfo
 import kr.linkerbell.campusmarket.android.domain.model.feature.trade.LikedItemInfo
@@ -20,6 +18,7 @@ import kr.linkerbell.campusmarket.android.domain.model.feature.trade.SummarizedT
 import kr.linkerbell.campusmarket.android.domain.model.feature.trade.TradeContents
 import kr.linkerbell.campusmarket.android.domain.model.feature.trade.TradeInfo
 import kr.linkerbell.campusmarket.android.domain.repository.feature.TradeRepository
+import javax.inject.Inject
 
 class RealTradeRepository @Inject constructor(
     private val tradeApi: TradeApi,
@@ -135,5 +134,4 @@ class RealTradeRepository @Inject constructor(
             rating
         )
     }
-
 }

--- a/data/src/main/kotlin/kr/linkerbell/campusmarket/android/data/repository/feature/trade/paging/SearchTradePagingSource.kt
+++ b/data/src/main/kotlin/kr/linkerbell/campusmarket/android/data/repository/feature/trade/paging/SearchTradePagingSource.kt
@@ -31,9 +31,9 @@ class SearchTradePagingSource(
             category = category,
             minPrice = minPrice,
             maxPrice = maxPrice,
-            sorted = sorted,
-            pageNum = pageNum,
-            pageSize = pageSize
+            sort = sorted,
+            page = pageNum,
+            size = pageSize
         ).map { data ->
             val nextPage = if (data.hasNext) pageNum + 1 else null
             val previousPage = if (data.hasPrevious) pageNum - 1 else null

--- a/domain/src/main/kotlin/kr/linkerbell/campusmarket/android/domain/model/feature/mypage/RecentTrade.kt
+++ b/domain/src/main/kotlin/kr/linkerbell/campusmarket/android/domain/model/feature/mypage/RecentTrade.kt
@@ -1,0 +1,9 @@
+package kr.linkerbell.campusmarket.android.domain.model.feature.mypage
+
+data class RecentTrade(
+    val id: Long,
+    val title: String,
+    val price: Int,
+    val thumbnail: String,
+    val isSold: Boolean
+)

--- a/domain/src/main/kotlin/kr/linkerbell/campusmarket/android/domain/model/feature/mypage/UserReview.kt
+++ b/domain/src/main/kotlin/kr/linkerbell/campusmarket/android/domain/model/feature/mypage/UserReview.kt
@@ -1,0 +1,12 @@
+package kr.linkerbell.campusmarket.android.domain.model.feature.mypage
+
+import kotlinx.datetime.LocalDateTime
+
+data class UserReview(
+    val userId: Long,
+    val nickname: String,
+    val profileImage: String,
+    val description: String,
+    val rating: Int,
+    val createdAt: LocalDateTime
+)

--- a/domain/src/main/kotlin/kr/linkerbell/campusmarket/android/domain/repository/feature/MyPageRepository.kt
+++ b/domain/src/main/kotlin/kr/linkerbell/campusmarket/android/domain/repository/feature/MyPageRepository.kt
@@ -1,0 +1,18 @@
+package kr.linkerbell.campusmarket.android.domain.repository.feature
+
+import androidx.paging.PagingData
+import kotlinx.coroutines.flow.Flow
+import kr.linkerbell.campusmarket.android.domain.model.feature.mypage.RecentTrade
+import kr.linkerbell.campusmarket.android.domain.model.feature.mypage.UserReview
+
+interface MyPageRepository {
+
+    suspend fun getUserReviews(
+        userId: Long
+    ): Flow<PagingData<UserReview>>
+
+    suspend fun getRecentTrades(
+        userId: Long,
+        type: String
+    ): Flow<PagingData<RecentTrade>>
+}

--- a/domain/src/main/kotlin/kr/linkerbell/campusmarket/android/domain/repository/feature/TradeRepository.kt
+++ b/domain/src/main/kotlin/kr/linkerbell/campusmarket/android/domain/repository/feature/TradeRepository.kt
@@ -2,7 +2,6 @@ package kr.linkerbell.campusmarket.android.domain.repository.feature
 
 import androidx.paging.PagingData
 import kotlinx.coroutines.flow.Flow
-import kr.linkerbell.campusmarket.android.domain.model.feature.mypage.UserReview
 import kr.linkerbell.campusmarket.android.domain.model.feature.trade.CategoryList
 import kr.linkerbell.campusmarket.android.domain.model.feature.trade.DeletedLikedItemInfo
 import kr.linkerbell.campusmarket.android.domain.model.feature.trade.LikedItemInfo
@@ -60,5 +59,5 @@ interface TradeRepository {
         itemId: Long,
         description: String,
         rating: Int
-    ) : Result<Unit>
+    ): Result<Unit>
 }

--- a/domain/src/main/kotlin/kr/linkerbell/campusmarket/android/domain/repository/feature/TradeRepository.kt
+++ b/domain/src/main/kotlin/kr/linkerbell/campusmarket/android/domain/repository/feature/TradeRepository.kt
@@ -2,6 +2,7 @@ package kr.linkerbell.campusmarket.android.domain.repository.feature
 
 import androidx.paging.PagingData
 import kotlinx.coroutines.flow.Flow
+import kr.linkerbell.campusmarket.android.domain.model.feature.mypage.UserReview
 import kr.linkerbell.campusmarket.android.domain.model.feature.trade.CategoryList
 import kr.linkerbell.campusmarket.android.domain.model.feature.trade.DeletedLikedItemInfo
 import kr.linkerbell.campusmarket.android.domain.model.feature.trade.LikedItemInfo

--- a/domain/src/main/kotlin/kr/linkerbell/campusmarket/android/domain/usecase/feature/myprofile/GetRecentTradeListUseCase.kt
+++ b/domain/src/main/kotlin/kr/linkerbell/campusmarket/android/domain/usecase/feature/myprofile/GetRecentTradeListUseCase.kt
@@ -1,0 +1,18 @@
+package kr.linkerbell.campusmarket.android.domain.usecase.feature.myprofile
+
+import androidx.paging.PagingData
+import kotlinx.coroutines.flow.Flow
+import kr.linkerbell.campusmarket.android.domain.model.feature.mypage.RecentTrade
+import kr.linkerbell.campusmarket.android.domain.repository.feature.MyPageRepository
+import javax.inject.Inject
+
+class GetRecentTradeListUseCase @Inject constructor(
+    private val myPageRepository: MyPageRepository
+) {
+    suspend operator fun invoke(
+        userId: Long,
+        type: String
+    ): Flow<PagingData<RecentTrade>> {
+        return myPageRepository.getRecentTrades(userId = userId, type = type)
+    }
+}

--- a/domain/src/main/kotlin/kr/linkerbell/campusmarket/android/domain/usecase/feature/myprofile/GetUserReviewUseCase.kt
+++ b/domain/src/main/kotlin/kr/linkerbell/campusmarket/android/domain/usecase/feature/myprofile/GetUserReviewUseCase.kt
@@ -1,0 +1,18 @@
+package kr.linkerbell.campusmarket.android.domain.usecase.feature.myprofile
+
+import androidx.paging.PagingData
+import javax.inject.Inject
+import kotlinx.coroutines.flow.Flow
+import kr.linkerbell.campusmarket.android.domain.model.feature.mypage.UserReview
+import kr.linkerbell.campusmarket.android.domain.repository.feature.MyPageRepository
+import kr.linkerbell.campusmarket.android.domain.repository.feature.TradeRepository
+
+class GetUserReviewUseCase @Inject constructor(
+    private val myPageRepository: MyPageRepository
+) {
+    suspend operator fun invoke(
+        userId: Long
+    ): Flow<PagingData<UserReview>> {
+        return myPageRepository.getUserReviews(userId = userId)
+    }
+}

--- a/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/MainDestination.kt
+++ b/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/MainDestination.kt
@@ -4,13 +4,16 @@ import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import kr.linkerbell.campusmarket.android.presentation.ui.main.home.chatroom.chat.chatDestination
 import kr.linkerbell.campusmarket.android.presentation.ui.main.home.homeDestination
+import kr.linkerbell.campusmarket.android.presentation.ui.main.home.mypage.userprofile.recent_review.recentReviewDestination
 import kr.linkerbell.campusmarket.android.presentation.ui.main.home.mypage.changecampus.changeCampusDestination
 import kr.linkerbell.campusmarket.android.presentation.ui.main.home.mypage.logout.logoutDestination
 import kr.linkerbell.campusmarket.android.presentation.ui.main.home.mypage.logout.withdrawal.withdrawalDestination
+import kr.linkerbell.campusmarket.android.presentation.ui.main.home.mypage.rating.ratingDestination
+import kr.linkerbell.campusmarket.android.presentation.ui.main.home.mypage.userprofile.recent_trade.recentTradeDestination
+import kr.linkerbell.campusmarket.android.presentation.ui.main.home.mypage.userprofile.userProfileDestination
 import kr.linkerbell.campusmarket.android.presentation.ui.main.home.schedule.compare.scheduleCompareDestination
 import kr.linkerbell.campusmarket.android.presentation.ui.main.home.trade.info.tradeInfoDestination
 import kr.linkerbell.campusmarket.android.presentation.ui.main.home.trade.post.tradePostDestination
-import kr.linkerbell.campusmarket.android.presentation.ui.main.home.mypage.rating.ratingDestination
 import kr.linkerbell.campusmarket.android.presentation.ui.main.home.trade.search.result.tradeSearchResultDestination
 import kr.linkerbell.campusmarket.android.presentation.ui.main.home.trade.search.tradeSearchDestination
 import kr.linkerbell.campusmarket.android.presentation.ui.main.nonlogin.nonLoginNavGraphNavGraph
@@ -29,6 +32,9 @@ fun NavGraphBuilder.mainDestination(
     tradeInfoDestination(navController = navController)
 
     ratingDestination(navController = navController)
+    userProfileDestination(navController = navController)
+    recentTradeDestination(navController = navController)
+    recentReviewDestination(navController = navController)
 
     chatDestination(navController = navController)
 

--- a/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/mypage/userprofile/UserProfileArgument.kt
+++ b/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/mypage/userprofile/UserProfileArgument.kt
@@ -1,0 +1,25 @@
+package kr.linkerbell.campusmarket.android.presentation.ui.main.home.mypage.userprofile
+
+import androidx.compose.runtime.Immutable
+import kr.linkerbell.campusmarket.android.common.util.coroutine.event.EventFlow
+import kotlin.coroutines.CoroutineContext
+
+@Immutable
+data class UserProfileArgument(
+    val state: UserProfileState,
+    val event: EventFlow<UserProfileEvent>,
+    val intent: (UserProfileIntent) -> Unit,
+    val logEvent: (eventName: String, params: Map<String, Any>) -> Unit,
+    val coroutineContext: CoroutineContext
+)
+
+sealed interface UserProfileState {
+    data object Init : UserProfileState
+    data object Loading : UserProfileState
+}
+
+sealed interface UserProfileEvent
+
+sealed interface UserProfileIntent {
+    data object RefreshUserProfile : UserProfileIntent
+}

--- a/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/mypage/userprofile/UserProfileConstant.kt
+++ b/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/mypage/userprofile/UserProfileConstant.kt
@@ -1,0 +1,10 @@
+package kr.linkerbell.campusmarket.android.presentation.ui.main.home.mypage.userprofile
+
+object UserProfileConstant {
+    const val ROUTE: String = "userProfile"
+
+    const val ROUTE_ARGUMENT_USER_ID = "userId"
+
+    const val ROUTE_STRUCTURE = ROUTE +
+            "?$ROUTE_ARGUMENT_USER_ID={$ROUTE_ARGUMENT_USER_ID}"
+}

--- a/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/mypage/userprofile/UserProfileData.kt
+++ b/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/mypage/userprofile/UserProfileData.kt
@@ -1,0 +1,14 @@
+package kr.linkerbell.campusmarket.android.presentation.ui.main.home.mypage.userprofile
+
+import androidx.compose.runtime.Immutable
+import androidx.paging.compose.LazyPagingItems
+import kr.linkerbell.campusmarket.android.domain.model.feature.mypage.RecentTrade
+import kr.linkerbell.campusmarket.android.domain.model.feature.mypage.UserReview
+import kr.linkerbell.campusmarket.android.domain.model.nonfeature.user.UserProfile
+
+@Immutable
+data class UserProfileData(
+    val userProfile: UserProfile,
+    val recentReviews: LazyPagingItems<UserReview>,
+    val recentTrades: LazyPagingItems<RecentTrade>
+)

--- a/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/mypage/userprofile/UserProfileDestination.kt
+++ b/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/mypage/userprofile/UserProfileDestination.kt
@@ -1,0 +1,59 @@
+package kr.linkerbell.campusmarket.android.presentation.ui.main.home.mypage.userprofile
+
+import androidx.compose.runtime.getValue
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.navigation.NavController
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavType
+import androidx.navigation.compose.composable
+import androidx.navigation.navArgument
+import androidx.paging.compose.collectAsLazyPagingItems
+import kr.linkerbell.campusmarket.android.presentation.common.util.compose.ErrorObserver
+
+fun NavGraphBuilder.userProfileDestination(
+    navController: NavController
+) {
+    composable(
+        route = UserProfileConstant.ROUTE_STRUCTURE,
+        arguments = listOf(
+            navArgument(UserProfileConstant.ROUTE_ARGUMENT_USER_ID) {
+                type = NavType.LongType
+                defaultValue = -1L
+            }
+        )
+    ) {
+        val viewModel: UserProfileViewModel = hiltViewModel()
+
+        val argument: UserProfileArgument = let {
+            val state by viewModel.state.collectAsStateWithLifecycle()
+
+            UserProfileArgument(
+                state = state,
+                event = viewModel.event,
+                intent = viewModel::onIntent,
+                logEvent = viewModel::logEvent,
+                coroutineContext = viewModel.coroutineContext
+            )
+        }
+
+        val data: UserProfileData = let {
+            val userProfile by viewModel.userProfile.collectAsStateWithLifecycle()
+            val recentReviews = viewModel.recentReviews.collectAsLazyPagingItems()
+            val recentTrades = viewModel.recentTrades.collectAsLazyPagingItems()
+
+            UserProfileData(
+                userProfile = userProfile,
+                recentReviews = recentReviews,
+                recentTrades = recentTrades
+            )
+        }
+
+        ErrorObserver(viewModel)
+        UserProfileScreen(
+            navController = navController,
+            argument = argument,
+            data = data
+        )
+    }
+}

--- a/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/mypage/userprofile/UserProfileScreen.kt
+++ b/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/mypage/userprofile/UserProfileScreen.kt
@@ -1,0 +1,561 @@
+package kr.linkerbell.campusmarket.android.presentation.ui.main.home.mypage.userprofile
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CardDefaults.cardElevation
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color.Companion.LightGray
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.constraintlayout.compose.ConstraintLayout
+import androidx.constraintlayout.compose.Dimension
+import androidx.navigation.NavController
+import androidx.navigation.compose.rememberNavController
+import androidx.paging.PagingData
+import androidx.paging.compose.collectAsLazyPagingItems
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.plus
+import kotlinx.datetime.LocalDateTime
+import kr.linkerbell.campusmarket.android.common.util.coroutine.event.MutableEventFlow
+import kr.linkerbell.campusmarket.android.domain.model.feature.mypage.RecentTrade
+import kr.linkerbell.campusmarket.android.domain.model.feature.mypage.UserReview
+import kr.linkerbell.campusmarket.android.domain.model.nonfeature.user.UserProfile
+import kr.linkerbell.campusmarket.android.presentation.R
+import kr.linkerbell.campusmarket.android.presentation.common.theme.Black
+import kr.linkerbell.campusmarket.android.presentation.common.theme.Blue100
+import kr.linkerbell.campusmarket.android.presentation.common.theme.Blue400
+import kr.linkerbell.campusmarket.android.presentation.common.theme.Body1
+import kr.linkerbell.campusmarket.android.presentation.common.theme.Body2
+import kr.linkerbell.campusmarket.android.presentation.common.theme.Caption2
+import kr.linkerbell.campusmarket.android.presentation.common.theme.Gray200
+import kr.linkerbell.campusmarket.android.presentation.common.theme.Gray600
+import kr.linkerbell.campusmarket.android.presentation.common.theme.Gray900
+import kr.linkerbell.campusmarket.android.presentation.common.theme.Headline1
+import kr.linkerbell.campusmarket.android.presentation.common.theme.Headline2
+import kr.linkerbell.campusmarket.android.presentation.common.theme.Headline3
+import kr.linkerbell.campusmarket.android.presentation.common.theme.Space56
+import kr.linkerbell.campusmarket.android.presentation.common.theme.White
+import kr.linkerbell.campusmarket.android.presentation.common.util.compose.LaunchedEffectWithLifecycle
+import kr.linkerbell.campusmarket.android.presentation.common.util.compose.makeRoute
+import kr.linkerbell.campusmarket.android.presentation.common.util.compose.safeNavigateUp
+import kr.linkerbell.campusmarket.android.presentation.common.view.RippleBox
+import kr.linkerbell.campusmarket.android.presentation.common.view.image.PostImage
+import kr.linkerbell.campusmarket.android.presentation.ui.main.home.mypage.userprofile.recent_review.RecentReviewConstant
+import kr.linkerbell.campusmarket.android.presentation.ui.main.home.mypage.userprofile.recent_trade.RecentTradeConstant
+import kr.linkerbell.campusmarket.android.presentation.ui.main.home.trade.info.TradeInfoConstant
+
+@Composable
+fun UserProfileScreen(
+    navController: NavController,
+    argument: UserProfileArgument,
+    data: UserProfileData
+) {
+    val (state, event, intent, logEvent, coroutineContext) = argument
+    val scope = rememberCoroutineScope() + coroutineContext
+
+    val userprofile = data.userProfile
+
+    var isNewScreenLoadingAvailable by remember { mutableStateOf(false) }
+
+    ConstraintLayout(
+        modifier = Modifier
+            .background(White)
+            .fillMaxSize()
+    ) {
+        val (topBar, contents) = createRefs()
+        Row(
+            modifier = Modifier
+                .height(Space56)
+                .fillMaxWidth()
+                .constrainAs(topBar) {
+                    top.linkTo(parent.top)
+                    start.linkTo(parent.start)
+                    end.linkTo(parent.end)
+                },
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            RippleBox(
+                modifier = Modifier
+                    .padding(4.dp),
+                onClick = {
+                    navController.safeNavigateUp()
+                }
+            ) {
+                Icon(
+                    painter = painterResource(R.drawable.ic_chevron_left),
+                    contentDescription = "Navigate Up Button",
+                    modifier = Modifier
+                        .size(48.dp)
+                        .padding(horizontal = 8.dp)
+                )
+            }
+            Text(
+                text = "작성자 정보",
+                style = Headline2
+            )
+        }
+        Column(
+            modifier = Modifier
+                .verticalScroll(rememberScrollState())
+                .padding(8.dp)
+                .constrainAs(contents) {
+                    top.linkTo(topBar.bottom)
+                    start.linkTo(parent.start)
+                    end.linkTo(parent.end)
+                    bottom.linkTo(parent.bottom)
+                    width = Dimension.fillToConstraints
+                    height = Dimension.fillToConstraints
+                }
+        ) {
+            UserProfileInfo(userProfile = userprofile)
+            HorizontalDivider(
+                thickness = 1.dp,
+                color = Gray900,
+                modifier = Modifier.padding(horizontal = 2.dp, vertical = 16.dp)
+            )
+            Column(
+                modifier = Modifier.padding(8.dp)
+            ) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.SpaceBetween
+                ) {
+                    Text(
+                        text = "최근 판매",
+                        style = Headline1,
+                        color = Black,
+                    )
+                    Text(
+                        text = "더보기",
+                        style = Caption2,
+                        color = Gray600,
+                        modifier = Modifier.clickable {
+                            if (isNewScreenLoadingAvailable) {
+                                isNewScreenLoadingAvailable = false
+                                val newRoute = makeRoute(
+                                    route = RecentTradeConstant.ROUTE,
+                                    arguments = mapOf(
+                                        RecentTradeConstant.ROUTE_ARGUMENT_USER_ID to data.userProfile.id,
+                                    )
+                                )
+                                navController.navigate(newRoute)
+                            }
+                        }
+                    )
+                }
+                Column {
+                    val recentTrades = data.recentTrades
+                    if (recentTrades.itemCount == 0) {
+                        Text(
+                            text = "아직 판매중인 물건이 없어요",
+                            style = Caption2,
+                            color = Gray600,
+                            modifier = Modifier.padding(start = 8.dp, top = 8.dp)
+                        )
+                    } else {
+                        for (index in 0..<recentTrades.itemCount) {
+                            val trade = recentTrades[index]
+                            if (trade != null && index < 3) {
+                                Spacer(modifier = Modifier.padding(4.dp))
+                                TradeHistoryCard(
+                                    recentTrade = trade,
+                                    onClicked = {
+                                        val tradeInfoRoute = makeRoute(
+                                            route = TradeInfoConstant.ROUTE,
+                                            arguments = mapOf(
+                                                TradeInfoConstant.ROUTE_ARGUMENT_ITEM_ID
+                                                        to trade.id.toString()
+                                            )
+                                        )
+                                        navController.navigate(tradeInfoRoute)
+                                    }
+                                )
+                            } else {
+                                break
+                            }
+                        }
+                    }
+                }
+                Spacer(modifier = Modifier.padding(8.dp))
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.SpaceBetween
+                ) {
+                    Text(
+                        text = "최근 평가",
+                        style = Headline1,
+                        color = Black,
+                    )
+                    Text(
+                        text = "더보기",
+                        style = Caption2,
+                        color = Gray600,
+                        modifier = Modifier.clickable {
+                            if (isNewScreenLoadingAvailable) {
+                                isNewScreenLoadingAvailable = false
+                                val newRoute = makeRoute(
+                                    route = RecentReviewConstant.ROUTE,
+                                    arguments = mapOf(
+                                        RecentReviewConstant.ROUTE_ARGUMENT_USER_ID to data.userProfile.id,
+                                    )
+                                )
+                                navController.navigate(newRoute)
+                            }
+                        }
+                    )
+                }
+                Column {
+                    val recentReview = data.recentReviews
+                    if (recentReview.itemCount == 0) {
+                        Text(
+                            text = "아직 작성된 리뷰가 없어요",
+                            style = Caption2,
+                            color = Gray600,
+                            modifier = Modifier.padding(start = 8.dp, top = 8.dp)
+                        )
+                    } else {
+                        for (index in 0..<recentReview.itemCount) {
+                            val review = recentReview[index]
+                            if (review != null && index < 3) {
+                                Spacer(modifier = Modifier.padding(4.dp))
+                                ReviewCard(review)
+                            } else {
+                                break
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    LaunchedEffectWithLifecycle(coroutineContext) {
+        argument.intent(UserProfileIntent.RefreshUserProfile)
+        isNewScreenLoadingAvailable = true
+    }
+}
+
+@Composable
+private fun TradeHistoryCard(
+    recentTrade: RecentTrade,
+    onClicked: () -> Unit
+) {
+    Row(
+        modifier = Modifier
+            .clip(RoundedCornerShape(8.dp))
+            .background(Gray200)
+            .fillMaxWidth()
+            .padding(8.dp)
+            .clickable {
+                onClicked()
+            }
+    ) {
+        PostImage(
+            data = recentTrade.thumbnail,
+            modifier = Modifier
+                .size(80.dp)
+                .clip(RoundedCornerShape(8.dp))
+        )
+        Column(modifier = Modifier.padding(start = 8.dp)) {
+            Text(
+                text = recentTrade.title,
+                style = Headline2,
+                color = Black,
+            )
+            Spacer(modifier = Modifier.padding(bottom = 8.dp))
+            Text(
+                text = "${recentTrade.price} 원",
+                style = Headline3,
+                color = Black,
+            )
+        }
+        Box(
+            modifier = Modifier.fillMaxWidth(),
+            contentAlignment = Alignment.TopEnd
+        ) {
+            TradeItemStatus(recentTrade.isSold)
+        }
+    }
+}
+
+@Composable
+private fun TradeItemStatus(isSold: Boolean) {
+    val backgroundColor = if (isSold) LightGray else Blue100
+    val text = if (isSold) "거래 완료" else "거래 가능"
+
+    Box(
+        modifier = Modifier
+            .clip(RoundedCornerShape(5.dp))
+            .background(backgroundColor),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(
+            text = text,
+            style = Body1,
+            color = White,
+            modifier = Modifier.padding(horizontal = 4.dp, vertical = 2.dp)
+        )
+    }
+}
+
+@Composable
+private fun ReviewCard(review: UserReview) {
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(8.dp))
+            .background(Gray200)
+            .padding(8.dp)
+    ) {
+        Row {
+            PostImage(
+                data = review.profileImage,
+                modifier = Modifier
+                    .size(40.dp)
+                    .clip(RoundedCornerShape(12.dp))
+                    .background(
+                        color = White,
+                        shape = RoundedCornerShape(4.dp)
+                    )
+                    .border(
+                        1.dp,
+                        Gray900,
+                        shape = RoundedCornerShape(12.dp)
+                    )
+            )
+            Column(
+                modifier = Modifier.padding(start = 8.dp),
+                verticalArrangement = Arrangement.SpaceEvenly
+            ) {
+                Row(
+                    modifier = Modifier.padding(bottom = 4.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text(
+                        text = review.nickname,
+                        style = Headline2,
+                        color = Black
+                    )
+                    Text(
+                        text = review.createdAt.date.toString(),
+                        style = Body2,
+                        color = Gray600,
+                        modifier = Modifier.padding(start = 4.dp)
+                    )
+                }
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    RatingStars(
+                        rating = review.rating,
+                        starSize = 14.dp,
+                        interval = 2.dp
+                    )
+                    Text(
+                        text = "(${review.rating})",
+                        style = Body2,
+                        color = Black,
+                        modifier = Modifier.padding(start = 4.dp)
+                    )
+                }
+            }
+        }
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = 4.dp)
+        ) {
+            Text(
+                text = review.description,
+                overflow = TextOverflow.Ellipsis,
+                maxLines = 4,
+                style = Body1,
+                color = Gray900,
+                modifier = Modifier.padding(4.dp)
+            )
+        }
+    }
+}
+
+@Composable
+private fun RatingStars(
+    rating: Int = 0,
+    starSize: Dp = 20.dp,
+    interval: Dp = 4.dp
+) {
+    val adjustedRating = rating.coerceIn(0, 10)
+
+    @Composable
+    fun StarImage(resourceId: Int, size: Dp) {
+        Image(
+            painter = painterResource(id = resourceId),
+            contentDescription = null,
+            colorFilter = ColorFilter.tint(Blue400),
+            modifier = Modifier.size(size)
+        )
+    }
+
+    Row {
+        repeat(5) { index ->
+            val starPoints = (index + 1) * 2
+            val resource = when {
+                adjustedRating >= starPoints -> R.drawable.filled_star
+                adjustedRating >= starPoints - 1 -> R.drawable.half_filled_star
+                else -> R.drawable.empty_star
+            }
+            StarImage(resource, starSize)
+            Spacer(modifier = Modifier.padding(end = interval))
+        }
+    }
+}
+
+@Composable
+private fun UserProfileInfo(
+    userProfile: UserProfile
+) {
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Card(
+            modifier = Modifier.size(150.dp),
+            shape = CircleShape,
+            colors = CardDefaults.cardColors(White),
+            elevation = cardElevation(0.dp, 0.dp, 0.dp, 0.dp, 0.dp, 0.dp),
+            border = BorderStroke(3.dp, Blue400)
+        ) {
+            PostImage(
+                data = userProfile.profileImage,
+                modifier = Modifier.fillMaxSize()
+            )
+        }
+
+        Column(
+            modifier = Modifier.padding(16.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Text(
+                text = userProfile.nickname,
+                style = Headline1,
+                color = Black,
+            )
+            Spacer(modifier = Modifier.padding(bottom = 8.dp))
+            Row(
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Icon(
+                    modifier = Modifier.size(16.dp),
+                    painter = painterResource(R.drawable.filled_star),
+                    contentDescription = null,
+                    tint = Blue400
+                )
+                Text(
+                    text = " (${userProfile.rating}/10)",
+                    style = Body1,
+                    color = Black,
+                )
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun OtherUserProfileScreenPreview() {
+    UserProfileScreen(
+        navController = rememberNavController(),
+        argument = UserProfileArgument(
+            state = UserProfileState.Init,
+            event = MutableEventFlow(),
+            intent = {},
+            logEvent = { _, _ -> },
+            coroutineContext = Dispatchers.IO
+        ),
+        data = UserProfileData(
+            UserProfile(
+                id = 959L,
+                nickname = "user3205",
+                profileImage = "https://picsum.photos/200",
+                rating = 4.4
+            ),
+            recentReviews = MutableStateFlow(
+                PagingData.from(
+                    listOf(
+                        UserReview(
+                            userId = 0L,
+                            nickname = "reviewer_1",
+                            profileImage = "",
+                            description = "좋아요",
+                            rating = 7,
+                            createdAt = LocalDateTime(2024, 11, 22, 15, 30, 0)
+                        ),
+                        UserReview(
+                            userId = 0L,
+                            nickname = "reviewer_2",
+                            profileImage = "",
+                            description = "아주 좋아요",
+                            rating = 10,
+                            createdAt = LocalDateTime(2024, 11, 22, 15, 30, 0)
+                        )
+                    )
+                )
+            ).collectAsLazyPagingItems(),
+            recentTrades = MutableStateFlow(
+                PagingData.from(
+                    listOf(
+                        RecentTrade(
+                            id = 1L,
+                            title = "Used Laptop",
+                            price = 150000,
+                            thumbnail = "https://example.com/image1.jpg",
+                            isSold = false
+                        ),
+                        RecentTrade(
+                            id = 2L,
+                            title = "Antique Vase",
+                            price = 20000,
+                            thumbnail = "https://example.com/image2.jpg",
+                            isSold = true
+                        )
+                    )
+                )
+            ).collectAsLazyPagingItems()
+        )
+    )
+}

--- a/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/mypage/userprofile/UserProfileViewModel.kt
+++ b/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/mypage/userprofile/UserProfileViewModel.kt
@@ -1,0 +1,130 @@
+package kr.linkerbell.campusmarket.android.presentation.ui.main.home.mypage.userprofile
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.viewModelScope
+import androidx.paging.PagingData
+import androidx.paging.cachedIn
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.catch
+import kr.linkerbell.campusmarket.android.common.util.coroutine.event.EventFlow
+import kr.linkerbell.campusmarket.android.common.util.coroutine.event.MutableEventFlow
+import kr.linkerbell.campusmarket.android.common.util.coroutine.event.asEventFlow
+import kr.linkerbell.campusmarket.android.domain.model.feature.mypage.RecentTrade
+import kr.linkerbell.campusmarket.android.domain.model.feature.mypage.UserReview
+import kr.linkerbell.campusmarket.android.domain.model.nonfeature.error.ServerException
+import kr.linkerbell.campusmarket.android.domain.model.nonfeature.user.UserProfile
+import kr.linkerbell.campusmarket.android.domain.usecase.feature.myprofile.GetRecentTradeListUseCase
+import kr.linkerbell.campusmarket.android.domain.usecase.feature.myprofile.GetUserReviewUseCase
+import kr.linkerbell.campusmarket.android.domain.usecase.nonfeature.user.GetUserProfileUseCase
+import kr.linkerbell.campusmarket.android.presentation.common.base.BaseViewModel
+import kr.linkerbell.campusmarket.android.presentation.common.base.ErrorEvent
+import javax.inject.Inject
+
+@HiltViewModel
+class UserProfileViewModel @Inject constructor(
+    private val savedStateHandle: SavedStateHandle,
+    private val getUserProfileUseCase: GetUserProfileUseCase,
+    private val getUserReviewUseCase: GetUserReviewUseCase,
+    private val getRecentTradeListUseCase: GetRecentTradeListUseCase
+) : BaseViewModel() {
+
+    private val _state: MutableStateFlow<UserProfileState> =
+        MutableStateFlow(UserProfileState.Init)
+    val state: StateFlow<UserProfileState> = _state.asStateFlow()
+
+    private val _event: MutableEventFlow<UserProfileEvent> = MutableEventFlow()
+    val event: EventFlow<UserProfileEvent> = _event.asEventFlow()
+
+    private val _userProfile: MutableStateFlow<UserProfile> = MutableStateFlow(UserProfile.empty)
+    val userProfile: StateFlow<UserProfile> = _userProfile.asStateFlow()
+
+    private val _recentReviews: MutableStateFlow<PagingData<UserReview>> =
+        MutableStateFlow(PagingData.empty())
+    val recentReviews: StateFlow<PagingData<UserReview>> = _recentReviews.asStateFlow()
+
+    private val _recentTrades: MutableStateFlow<PagingData<RecentTrade>> =
+        MutableStateFlow(PagingData.empty())
+    val recentTrades: StateFlow<PagingData<RecentTrade>> = _recentTrades.asStateFlow()
+
+    private val _userId: MutableStateFlow<Long> = MutableStateFlow(-1)
+
+    init {
+        launch {
+            _userId.value = savedStateHandle.get<Long>(UserProfileConstant.ROUTE_ARGUMENT_USER_ID) ?: -1L
+            updateUserProfile(_userId.value)
+        }
+    }
+
+    fun onIntent(intent: UserProfileIntent) {
+        when(intent){
+            is UserProfileIntent.RefreshUserProfile -> {
+                launch {
+                    updateUserProfile(_userId.value)
+                }
+            }
+        }
+    }
+
+    private suspend fun updateUserProfile(userId: Long) {
+        getOtherUserProfile(userId)
+        getOtherUserReviews(userId)
+        getOtherUserTradeHistory(userId)
+    }
+
+    private suspend fun getOtherUserProfile(userId: Long) {
+        getUserProfileUseCase(userId).onSuccess {
+            _state.value = UserProfileState.Init
+            _userProfile.value = it
+        }.onFailure { exception ->
+            when (exception) {
+                is ServerException -> {
+                    _errorEvent.emit(ErrorEvent.InvalidRequest(exception))
+                }
+
+                else -> {
+                    _errorEvent.emit(ErrorEvent.UnavailableServer(exception))
+                }
+            }
+            _userProfile.value = UserProfile.empty
+        }
+    }
+
+    private suspend fun getOtherUserReviews(userId: Long) {
+        getUserReviewUseCase(userId)
+            .cachedIn(viewModelScope)
+            .catch { exception ->
+                when (exception) {
+                    is ServerException -> {
+                        _errorEvent.emit(ErrorEvent.InvalidRequest(exception))
+                    }
+
+                    else -> {
+                        _errorEvent.emit(ErrorEvent.UnavailableServer(exception))
+                    }
+                }
+            }.collect {
+                _recentReviews.value = it
+            }
+    }
+
+    private suspend fun getOtherUserTradeHistory(userId: Long) {
+        getRecentTradeListUseCase(userId, type = "sales")
+            .cachedIn(viewModelScope)
+            .catch { exception ->
+                when (exception) {
+                    is ServerException -> {
+                        _errorEvent.emit(ErrorEvent.InvalidRequest(exception))
+                    }
+
+                    else -> {
+                        _errorEvent.emit(ErrorEvent.UnavailableServer(exception))
+                    }
+                }
+            }.collect {
+                _recentTrades.value = it
+            }
+    }
+}

--- a/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/mypage/userprofile/recent_review/RecentReviewArgument.kt
+++ b/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/mypage/userprofile/recent_review/RecentReviewArgument.kt
@@ -1,0 +1,23 @@
+package kr.linkerbell.campusmarket.android.presentation.ui.main.home.mypage.userprofile.recent_review
+
+import androidx.compose.runtime.Immutable
+import kotlin.coroutines.CoroutineContext
+import kr.linkerbell.campusmarket.android.common.util.coroutine.event.EventFlow
+
+@Immutable
+data class RecentReviewArgument(
+    val state: RecentReviewState,
+    val event: EventFlow<RecentReviewEvent>,
+    val intent: (RecentReviewIntent) -> Unit,
+    val logEvent: (eventName: String, params: Map<String, Any>) -> Unit,
+    val coroutineContext: CoroutineContext
+)
+
+sealed interface RecentReviewState {
+    data object Init : RecentReviewState
+    data object Loading : RecentReviewState
+}
+
+sealed interface RecentReviewEvent
+
+sealed interface RecentReviewIntent

--- a/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/mypage/userprofile/recent_review/RecentReviewConstant.kt
+++ b/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/mypage/userprofile/recent_review/RecentReviewConstant.kt
@@ -1,0 +1,12 @@
+package kr.linkerbell.campusmarket.android.presentation.ui.main.home.mypage.userprofile.recent_review
+
+import kr.linkerbell.campusmarket.android.presentation.ui.main.home.mypage.userprofile.UserProfileConstant
+
+object RecentReviewConstant {
+    const val ROUTE = "${UserProfileConstant.ROUTE}/recentReview"
+
+    const val ROUTE_ARGUMENT_USER_ID = "userId"
+
+    const val ROUTE_STRUCTURE = ROUTE +
+            "?$ROUTE_ARGUMENT_USER_ID={$ROUTE_ARGUMENT_USER_ID}"
+}

--- a/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/mypage/userprofile/recent_review/RecentReviewData.kt
+++ b/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/mypage/userprofile/recent_review/RecentReviewData.kt
@@ -1,0 +1,11 @@
+package kr.linkerbell.campusmarket.android.presentation.ui.main.home.mypage.userprofile.recent_review
+
+import androidx.compose.runtime.Immutable
+import androidx.paging.compose.LazyPagingItems
+import kr.linkerbell.campusmarket.android.domain.model.feature.mypage.UserReview
+import kr.linkerbell.campusmarket.android.domain.model.nonfeature.user.UserProfile
+
+@Immutable
+data class RecentReviewData(
+    val recentReviews: LazyPagingItems<UserReview>
+)

--- a/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/mypage/userprofile/recent_review/RecentReviewDestination.kt
+++ b/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/mypage/userprofile/recent_review/RecentReviewDestination.kt
@@ -1,0 +1,55 @@
+package kr.linkerbell.campusmarket.android.presentation.ui.main.home.mypage.userprofile.recent_review
+
+import androidx.compose.runtime.getValue
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.navigation.NavController
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavType
+import androidx.navigation.compose.composable
+import androidx.navigation.navArgument
+import androidx.paging.compose.collectAsLazyPagingItems
+import kr.linkerbell.campusmarket.android.presentation.common.util.compose.ErrorObserver
+
+fun NavGraphBuilder.recentReviewDestination(
+    navController: NavController
+) {
+    composable(
+        route = RecentReviewConstant.ROUTE_STRUCTURE,
+        arguments = listOf(
+            navArgument(RecentReviewConstant.ROUTE_ARGUMENT_USER_ID) {
+                type = NavType.LongType
+                defaultValue = -1L
+            }
+        )
+    ) {
+        val viewModel: RecentReviewViewModel = hiltViewModel()
+
+        val argument: RecentReviewArgument = let {
+            val state by viewModel.state.collectAsStateWithLifecycle()
+
+            RecentReviewArgument(
+                state = state,
+                event = viewModel.event,
+                intent = viewModel::onIntent,
+                logEvent = viewModel::logEvent,
+                coroutineContext = viewModel.coroutineContext
+            )
+        }
+
+        val data: RecentReviewData = let {
+            val recentReviews = viewModel.recentReviews.collectAsLazyPagingItems()
+
+            RecentReviewData(
+                recentReviews = recentReviews
+            )
+        }
+
+        ErrorObserver(viewModel)
+        RecentReviewScreen(
+            navController = navController,
+            argument = argument,
+            data = data
+        )
+    }
+}

--- a/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/mypage/userprofile/recent_review/RecentReviewScreen.kt
+++ b/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/mypage/userprofile/recent_review/RecentReviewScreen.kt
@@ -1,0 +1,298 @@
+package kr.linkerbell.campusmarket.android.presentation.ui.main.home.mypage.userprofile.recent_review
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.constraintlayout.compose.ConstraintLayout
+import androidx.constraintlayout.compose.Dimension
+import androidx.navigation.NavController
+import androidx.navigation.compose.rememberNavController
+import androidx.paging.PagingData
+import androidx.paging.compose.collectAsLazyPagingItems
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.plus
+import kotlinx.datetime.LocalDateTime
+import kr.linkerbell.campusmarket.android.common.util.coroutine.event.MutableEventFlow
+import kr.linkerbell.campusmarket.android.domain.model.feature.mypage.UserReview
+import kr.linkerbell.campusmarket.android.presentation.R
+import kr.linkerbell.campusmarket.android.presentation.common.theme.Black
+import kr.linkerbell.campusmarket.android.presentation.common.theme.Blue400
+import kr.linkerbell.campusmarket.android.presentation.common.theme.Body1
+import kr.linkerbell.campusmarket.android.presentation.common.theme.Body2
+import kr.linkerbell.campusmarket.android.presentation.common.theme.Caption2
+import kr.linkerbell.campusmarket.android.presentation.common.theme.Gray200
+import kr.linkerbell.campusmarket.android.presentation.common.theme.Gray600
+import kr.linkerbell.campusmarket.android.presentation.common.theme.Gray900
+import kr.linkerbell.campusmarket.android.presentation.common.theme.Headline2
+import kr.linkerbell.campusmarket.android.presentation.common.theme.Space56
+import kr.linkerbell.campusmarket.android.presentation.common.theme.White
+import kr.linkerbell.campusmarket.android.presentation.common.util.compose.safeNavigateUp
+import kr.linkerbell.campusmarket.android.presentation.common.view.RippleBox
+import kr.linkerbell.campusmarket.android.presentation.common.view.image.PostImage
+
+@Composable
+fun RecentReviewScreen(
+    navController: NavController,
+    argument: RecentReviewArgument,
+    data: RecentReviewData
+) {
+    val (state, event, intent, logEvent, coroutineContext) = argument
+    val scope = rememberCoroutineScope() + coroutineContext
+
+    val recentReviewList = data.recentReviews
+
+    ConstraintLayout(
+        modifier = Modifier
+            .background(White)
+            .fillMaxSize()
+    ) {
+        val (topBar, contents) = createRefs()
+        Row(
+            modifier = Modifier
+                .height(Space56)
+                .fillMaxWidth()
+                .constrainAs(topBar) {
+                    top.linkTo(parent.top)
+                    start.linkTo(parent.start)
+                    end.linkTo(parent.end)
+                },
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            RippleBox(
+                modifier = Modifier
+                    .padding(4.dp),
+                onClick = {
+                    navController.safeNavigateUp()
+                }
+            ) {
+                Icon(
+                    painter = painterResource(R.drawable.ic_chevron_left),
+                    contentDescription = "Navigate Up Button",
+                    modifier = Modifier
+                        .size(48.dp)
+                        .padding(horizontal = 8.dp)
+                )
+            }
+            Text(
+                text = "최근 평가",
+                style = Headline2
+            )
+        }
+        Column(
+            modifier = Modifier
+                .padding(vertical = 8.dp)
+                .constrainAs(contents) {
+                    top.linkTo(topBar.bottom)
+                    start.linkTo(parent.start)
+                    end.linkTo(parent.end)
+                    bottom.linkTo(parent.bottom)
+                    width = Dimension.fillToConstraints
+                    height = Dimension.fillToConstraints
+                }
+        ) {
+            if (recentReviewList.itemCount == 0) {
+                Box(
+                    modifier = Modifier.fillMaxWidth(),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Text(
+                        text = "아직 작성된 리뷰가 없어요",
+                        style = Caption2,
+                        color = Gray600,
+                        modifier = Modifier.padding(start = 8.dp, top = 8.dp)
+                    )
+                }
+            }
+            LazyColumn(
+                contentPadding = PaddingValues(vertical = 16.dp, horizontal = 20.dp)
+            ) {
+                items(
+                    count = recentReviewList.itemCount,
+                    key = { index ->
+                        "${recentReviewList[index]?.userId ?: -1}_" +
+                                "${recentReviewList[index]?.createdAt!!.date}".hashCode()
+                    }
+                ) { index ->
+                    val review = recentReviewList[index] ?: return@items
+                    ReviewCard(review)
+                    Spacer(modifier = Modifier.height(8.dp))
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ReviewCard(review: UserReview) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(8.dp))
+            .background(Gray200)
+            .padding(8.dp)
+    ) {
+        Row {
+            PostImage(
+                data = review.profileImage,
+                modifier = Modifier
+                    .size(40.dp)
+                    .clip(RoundedCornerShape(12.dp))
+                    .background(
+                        color = White,
+                        shape = RoundedCornerShape(4.dp)
+                    )
+                    .border(
+                        1.dp,
+                        Gray900,
+                        shape = RoundedCornerShape(12.dp)
+                    )
+            )
+            Column(
+                modifier = Modifier.padding(start = 8.dp),
+                verticalArrangement = Arrangement.SpaceEvenly
+            ) {
+                Row(
+                    modifier = Modifier.padding(bottom = 4.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text(
+                        text = review.nickname,
+                        style = Headline2,
+                        color = Black
+                    )
+                    Text(
+                        text = review.createdAt.date.toString(),
+                        style = Body2,
+                        color = Gray600,
+                        modifier = Modifier.padding(start = 4.dp)
+                    )
+                }
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    RatingStars(
+                        rating = review.rating,
+                        starSize = 14.dp,
+                        interval = 2.dp
+                    )
+                    Text(
+                        text = "(${review.rating})",
+                        style = Body2,
+                        color = Black,
+                        modifier = Modifier.padding(start = 4.dp)
+                    )
+                }
+            }
+        }
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = 4.dp)
+        ) {
+            Text(
+                text = review.description,
+                overflow = TextOverflow.Ellipsis,
+                maxLines = 4,
+                style = Body1,
+                color = Gray900,
+                modifier = Modifier.padding(4.dp)
+            )
+        }
+    }
+}
+
+@Composable
+private fun RatingStars(
+    rating: Int = 0,
+    starSize: Dp = 20.dp,
+    interval: Dp = 4.dp
+) {
+    val adjustedRating = rating.coerceIn(0, 10)
+
+    @Composable
+    fun StarImage(resourceId: Int, size: Dp) {
+        Image(
+            painter = painterResource(id = resourceId),
+            contentDescription = null,
+            colorFilter = ColorFilter.tint(Blue400),
+            modifier = Modifier.size(size)
+        )
+    }
+
+    Row {
+        repeat(5) { index ->
+            val starPoints = (index + 1) * 2
+            val resource = when {
+                adjustedRating >= starPoints -> R.drawable.filled_star
+                adjustedRating >= starPoints - 1 -> R.drawable.half_filled_star
+                else -> R.drawable.empty_star
+            }
+            StarImage(resource, starSize)
+            Spacer(modifier = Modifier.padding(end = interval))
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun RecentReviewScreenPreview() {
+    RecentReviewScreen(
+        navController = rememberNavController(),
+        argument = RecentReviewArgument(
+            state = RecentReviewState.Init,
+            event = MutableEventFlow(),
+            intent = {},
+            logEvent = { _, _ -> },
+            coroutineContext = Dispatchers.IO
+        ),
+        data = RecentReviewData(
+            recentReviews = MutableStateFlow(
+                PagingData.from(
+                    listOf(
+                        UserReview(
+                            userId = 0L,
+                            nickname = "reviewer_1",
+                            profileImage = "",
+                            description = "좋아요",
+                            rating = 7,
+                            createdAt = LocalDateTime(2024, 11, 22, 15, 30, 0)
+                        ),
+                        UserReview(
+                            userId = 0L,
+                            nickname = "reviewer_2",
+                            profileImage = "",
+                            description = "아주 좋아요",
+                            rating = 10,
+                            createdAt = LocalDateTime(2024, 11, 22, 15, 30, 0)
+                        )
+                    )
+                )
+            ).collectAsLazyPagingItems(),
+        )
+    )
+}

--- a/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/mypage/userprofile/recent_review/RecentReviewViewModel.kt
+++ b/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/mypage/userprofile/recent_review/RecentReviewViewModel.kt
@@ -1,0 +1,68 @@
+package kr.linkerbell.campusmarket.android.presentation.ui.main.home.mypage.userprofile.recent_review
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.viewModelScope
+import androidx.paging.PagingData
+import androidx.paging.cachedIn
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.catch
+import kr.linkerbell.campusmarket.android.common.util.coroutine.event.EventFlow
+import kr.linkerbell.campusmarket.android.common.util.coroutine.event.MutableEventFlow
+import kr.linkerbell.campusmarket.android.common.util.coroutine.event.asEventFlow
+import kr.linkerbell.campusmarket.android.domain.model.feature.mypage.UserReview
+import kr.linkerbell.campusmarket.android.domain.model.nonfeature.error.ServerException
+import kr.linkerbell.campusmarket.android.domain.usecase.feature.myprofile.GetUserReviewUseCase
+import kr.linkerbell.campusmarket.android.presentation.common.base.BaseViewModel
+import kr.linkerbell.campusmarket.android.presentation.common.base.ErrorEvent
+import javax.inject.Inject
+
+@HiltViewModel
+class RecentReviewViewModel @Inject constructor(
+    private val savedStateHandle: SavedStateHandle,
+    private val getUserReviewUseCase: GetUserReviewUseCase,
+) : BaseViewModel() {
+
+    private val _state: MutableStateFlow<RecentReviewState> =
+        MutableStateFlow(RecentReviewState.Init)
+    val state: StateFlow<RecentReviewState> = _state.asStateFlow()
+
+    private val _event: MutableEventFlow<RecentReviewEvent> = MutableEventFlow()
+    val event: EventFlow<RecentReviewEvent> = _event.asEventFlow()
+
+    private val _recentReviews: MutableStateFlow<PagingData<UserReview>> =
+        MutableStateFlow(PagingData.empty())
+    val recentReviews: StateFlow<PagingData<UserReview>> = _recentReviews.asStateFlow()
+
+    init {
+        launch {
+            val userId =
+                savedStateHandle.get<Long>(RecentReviewConstant.ROUTE_ARGUMENT_USER_ID) ?: -1L
+            getOtherUserReviews(userId)
+        }
+    }
+
+    fun onIntent(intent: RecentReviewIntent) {
+
+    }
+
+    private suspend fun getOtherUserReviews(userId: Long) {
+        getUserReviewUseCase(userId)
+            .cachedIn(viewModelScope)
+            .catch { exception ->
+                when (exception) {
+                    is ServerException -> {
+                        _errorEvent.emit(ErrorEvent.InvalidRequest(exception))
+                    }
+
+                    else -> {
+                        _errorEvent.emit(ErrorEvent.UnavailableServer(exception))
+                    }
+                }
+            }.collect {
+                _recentReviews.value = it
+            }
+    }
+}

--- a/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/mypage/userprofile/recent_trade/RecentTradeArgument.kt
+++ b/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/mypage/userprofile/recent_trade/RecentTradeArgument.kt
@@ -1,0 +1,23 @@
+package kr.linkerbell.campusmarket.android.presentation.ui.main.home.mypage.userprofile.recent_trade
+
+import androidx.compose.runtime.Immutable
+import kotlin.coroutines.CoroutineContext
+import kr.linkerbell.campusmarket.android.common.util.coroutine.event.EventFlow
+
+@Immutable
+data class RecentTradeArgument(
+    val state: RecentTradeState,
+    val event: EventFlow<RecentTradeEvent>,
+    val intent: (RecentTradeIntent) -> Unit,
+    val logEvent: (eventName: String, params: Map<String, Any>) -> Unit,
+    val coroutineContext: CoroutineContext
+)
+
+sealed interface RecentTradeState {
+    data object Init : RecentTradeState
+    data object Loading : RecentTradeState
+}
+
+sealed interface RecentTradeEvent
+
+sealed interface RecentTradeIntent

--- a/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/mypage/userprofile/recent_trade/RecentTradeConstant.kt
+++ b/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/mypage/userprofile/recent_trade/RecentTradeConstant.kt
@@ -1,0 +1,12 @@
+package kr.linkerbell.campusmarket.android.presentation.ui.main.home.mypage.userprofile.recent_trade
+
+import kr.linkerbell.campusmarket.android.presentation.ui.main.home.mypage.userprofile.UserProfileConstant
+
+object RecentTradeConstant {
+    const val ROUTE = "${UserProfileConstant.ROUTE}/recentTrade"
+
+    const val ROUTE_ARGUMENT_USER_ID = "userId"
+
+    const val ROUTE_STRUCTURE = ROUTE +
+            "?$ROUTE_ARGUMENT_USER_ID={$ROUTE_ARGUMENT_USER_ID}"
+}

--- a/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/mypage/userprofile/recent_trade/RecentTradeData.kt
+++ b/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/mypage/userprofile/recent_trade/RecentTradeData.kt
@@ -1,0 +1,10 @@
+package kr.linkerbell.campusmarket.android.presentation.ui.main.home.mypage.userprofile.recent_trade
+
+import androidx.compose.runtime.Immutable
+import androidx.paging.compose.LazyPagingItems
+import kr.linkerbell.campusmarket.android.domain.model.feature.mypage.RecentTrade
+
+@Immutable
+data class RecentTradeData(
+    val recentTrades: LazyPagingItems<RecentTrade>
+)

--- a/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/mypage/userprofile/recent_trade/RecentTradeDestination.kt
+++ b/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/mypage/userprofile/recent_trade/RecentTradeDestination.kt
@@ -1,0 +1,55 @@
+package kr.linkerbell.campusmarket.android.presentation.ui.main.home.mypage.userprofile.recent_trade
+
+import androidx.compose.runtime.getValue
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.navigation.NavController
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavType
+import androidx.navigation.compose.composable
+import androidx.navigation.navArgument
+import androidx.paging.compose.collectAsLazyPagingItems
+import kr.linkerbell.campusmarket.android.presentation.common.util.compose.ErrorObserver
+
+fun NavGraphBuilder.recentTradeDestination(
+    navController: NavController
+) {
+    composable(
+        route = RecentTradeConstant.ROUTE_STRUCTURE,
+        arguments = listOf(
+            navArgument(RecentTradeConstant.ROUTE_ARGUMENT_USER_ID) {
+                type = NavType.LongType
+                defaultValue = -1L
+            }
+        )
+    ) {
+        val viewModel: RecentTradeViewModel = hiltViewModel()
+
+        val argument: RecentTradeArgument = let {
+            val state by viewModel.state.collectAsStateWithLifecycle()
+
+            RecentTradeArgument(
+                state = state,
+                event = viewModel.event,
+                intent = viewModel::onIntent,
+                logEvent = viewModel::logEvent,
+                coroutineContext = viewModel.coroutineContext
+            )
+        }
+
+        val data: RecentTradeData = let {
+            val recentTrades = viewModel.recentTrades.collectAsLazyPagingItems()
+
+            RecentTradeData(
+                recentTrades = recentTrades
+            )
+        }
+
+        ErrorObserver(viewModel)
+        RecentTradeScreen(
+            navController = navController,
+            argument = argument,
+            data = data
+        )
+    }
+}

--- a/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/mypage/userprofile/recent_trade/RecentTradeScreen.kt
+++ b/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/mypage/userprofile/recent_trade/RecentTradeScreen.kt
@@ -1,0 +1,290 @@
+package kr.linkerbell.campusmarket.android.presentation.ui.main.home.mypage.userprofile.recent_trade
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color.Companion.LightGray
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.constraintlayout.compose.ConstraintLayout
+import androidx.constraintlayout.compose.Dimension
+import androidx.navigation.NavController
+import androidx.navigation.compose.rememberNavController
+import androidx.paging.PagingData
+import androidx.paging.compose.collectAsLazyPagingItems
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.plus
+import kr.linkerbell.campusmarket.android.common.util.coroutine.event.MutableEventFlow
+import kr.linkerbell.campusmarket.android.domain.model.feature.mypage.RecentTrade
+import kr.linkerbell.campusmarket.android.presentation.R
+import kr.linkerbell.campusmarket.android.presentation.common.theme.Black
+import kr.linkerbell.campusmarket.android.presentation.common.theme.Blue100
+import kr.linkerbell.campusmarket.android.presentation.common.theme.Blue400
+import kr.linkerbell.campusmarket.android.presentation.common.theme.Body1
+import kr.linkerbell.campusmarket.android.presentation.common.theme.Caption2
+import kr.linkerbell.campusmarket.android.presentation.common.theme.Gray200
+import kr.linkerbell.campusmarket.android.presentation.common.theme.Gray600
+import kr.linkerbell.campusmarket.android.presentation.common.theme.Headline2
+import kr.linkerbell.campusmarket.android.presentation.common.theme.Headline3
+import kr.linkerbell.campusmarket.android.presentation.common.theme.Space56
+import kr.linkerbell.campusmarket.android.presentation.common.theme.White
+import kr.linkerbell.campusmarket.android.presentation.common.util.compose.makeRoute
+import kr.linkerbell.campusmarket.android.presentation.common.util.compose.safeNavigateUp
+import kr.linkerbell.campusmarket.android.presentation.common.view.RippleBox
+import kr.linkerbell.campusmarket.android.presentation.common.view.image.PostImage
+import kr.linkerbell.campusmarket.android.presentation.ui.main.home.trade.info.TradeInfoConstant
+
+@Composable
+fun RecentTradeScreen(
+    navController: NavController,
+    argument: RecentTradeArgument,
+    data: RecentTradeData
+) {
+    val (state, event, intent, logEvent, coroutineContext) = argument
+    val scope = rememberCoroutineScope() + coroutineContext
+
+    val recentTradeList = data.recentTrades
+
+    ConstraintLayout(
+        modifier = Modifier
+            .background(White)
+            .fillMaxSize()
+    ) {
+        val (topBar, contents) = createRefs()
+        Row(
+            modifier = Modifier
+                .height(Space56)
+                .fillMaxWidth()
+                .constrainAs(topBar) {
+                    top.linkTo(parent.top)
+                    start.linkTo(parent.start)
+                    end.linkTo(parent.end)
+                },
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            RippleBox(
+                modifier = Modifier
+                    .padding(4.dp),
+                onClick = {
+                    navController.safeNavigateUp()
+                }
+            ) {
+                Icon(
+                    painter = painterResource(R.drawable.ic_chevron_left),
+                    contentDescription = "Navigate Up Button",
+                    modifier = Modifier
+                        .size(48.dp)
+                        .padding(horizontal = 8.dp)
+                )
+            }
+            Text(
+                text = "최근 판매",
+                style = Headline2
+            )
+        }
+        Column(
+            modifier = Modifier
+                .padding(vertical = 8.dp)
+                .constrainAs(contents) {
+                    top.linkTo(topBar.bottom)
+                    start.linkTo(parent.start)
+                    end.linkTo(parent.end)
+                    bottom.linkTo(parent.bottom)
+                    width = Dimension.fillToConstraints
+                    height = Dimension.fillToConstraints
+                }
+        ) {
+            if (recentTradeList.itemCount == 0) {
+                Box(
+                    modifier = Modifier.fillMaxWidth(),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Text(
+                        text = "아직 판매중인 물건이 없어요",
+                        style = Caption2,
+                        color = Gray600,
+                        modifier = Modifier.padding(start = 8.dp, top = 8.dp)
+                    )
+                }
+            }
+            LazyColumn(
+                contentPadding = PaddingValues(horizontal = 20.dp)
+            ) {
+                items(
+                    count = recentTradeList.itemCount,
+                    key = { index -> recentTradeList[index]?.id ?: -1 }
+                ) { index ->
+                    val trade = recentTradeList[index] ?: return@items
+                    TradeHistoryCard(
+                        recentTrade = trade,
+                        onClicked = {
+                            val tradeInfoRoute = makeRoute(
+                                route = TradeInfoConstant.ROUTE,
+                                arguments = mapOf(
+                                    TradeInfoConstant.ROUTE_ARGUMENT_ITEM_ID to trade.id.toString()
+                                )
+                            )
+                            navController.navigate(tradeInfoRoute)
+                        }
+                    )
+                    Spacer(modifier = Modifier.height(8.dp))
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun TradeHistoryCard(
+    recentTrade: RecentTrade,
+    onClicked: () -> Unit
+) {
+    Row(
+        modifier = Modifier
+            .clip(RoundedCornerShape(8.dp))
+            .background(Gray200)
+            .fillMaxWidth()
+            .padding(8.dp)
+            .clickable {
+                onClicked()
+            }
+    ) {
+        PostImage(
+            data = recentTrade.thumbnail,
+            modifier = Modifier
+                .size(80.dp)
+                .clip(RoundedCornerShape(8.dp))
+        )
+        Column(modifier = Modifier.padding(start = 8.dp)) {
+            Text(
+                text = recentTrade.title,
+                style = Headline2,
+                color = Black,
+            )
+            Spacer(modifier = Modifier.padding(bottom = 8.dp))
+            Text(
+                text = "${recentTrade.price} 원",
+                style = Headline3,
+                color = Black,
+            )
+        }
+        Box(
+            modifier = Modifier.fillMaxWidth(),
+            contentAlignment = Alignment.TopEnd
+        ) {
+            TradeItemStatus(recentTrade.isSold)
+        }
+    }
+}
+
+@Composable
+private fun TradeItemStatus(isSold: Boolean) {
+    val backgroundColor = if (isSold) LightGray else Blue100
+    val text = if (isSold) "거래 완료" else "거래 가능"
+
+    Box(
+        modifier = Modifier
+            .clip(RoundedCornerShape(5.dp))
+            .background(backgroundColor),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(
+            text = text,
+            style = Body1,
+            color = White,
+            modifier = Modifier.padding(horizontal = 4.dp, vertical = 2.dp)
+        )
+    }
+}
+
+@Composable
+private fun RatingStars(
+    rating: Int = 0,
+    starSize: Dp = 20.dp,
+    interval: Dp = 4.dp
+) {
+    val adjustedRating = rating.coerceIn(0, 10)
+
+    @Composable
+    fun StarImage(resourceId: Int, size: Dp) {
+        Image(
+            painter = painterResource(id = resourceId),
+            contentDescription = null,
+            colorFilter = ColorFilter.tint(Blue400),
+            modifier = Modifier.size(size)
+        )
+    }
+
+    Row {
+        repeat(5) { index ->
+            val starPoints = (index + 1) * 2
+            val resource = when {
+                adjustedRating >= starPoints -> R.drawable.filled_star
+                adjustedRating >= starPoints - 1 -> R.drawable.half_filled_star
+                else -> R.drawable.empty_star
+            }
+            StarImage(resource, starSize)
+            Spacer(modifier = Modifier.padding(end = interval))
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun RecentTradeScreenPreview() {
+    RecentTradeScreen(
+        navController = rememberNavController(),
+        argument = RecentTradeArgument(
+            state = RecentTradeState.Init,
+            event = MutableEventFlow(),
+            intent = {},
+            logEvent = { _, _ -> },
+            coroutineContext = Dispatchers.IO
+        ),
+        data = RecentTradeData(
+            recentTrades = MutableStateFlow(
+                PagingData.from(
+                    listOf(
+                        RecentTrade(
+                            id = 1L,
+                            title = "Used Laptop",
+                            price = 150000,
+                            thumbnail = "https://example.com/image1.jpg",
+                            isSold = false
+                        ),
+                        RecentTrade(
+                            id = 2L,
+                            title = "Antique Vase",
+                            price = 20000,
+                            thumbnail = "https://example.com/image2.jpg",
+                            isSold = true
+                        )
+                    )
+                )
+            ).collectAsLazyPagingItems()
+        )
+    )
+}

--- a/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/mypage/userprofile/recent_trade/RecentTradeViewModel.kt
+++ b/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/mypage/userprofile/recent_trade/RecentTradeViewModel.kt
@@ -1,0 +1,68 @@
+package kr.linkerbell.campusmarket.android.presentation.ui.main.home.mypage.userprofile.recent_trade
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.viewModelScope
+import androidx.paging.PagingData
+import androidx.paging.cachedIn
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.catch
+import kr.linkerbell.campusmarket.android.common.util.coroutine.event.EventFlow
+import kr.linkerbell.campusmarket.android.common.util.coroutine.event.MutableEventFlow
+import kr.linkerbell.campusmarket.android.common.util.coroutine.event.asEventFlow
+import kr.linkerbell.campusmarket.android.domain.model.feature.mypage.RecentTrade
+import kr.linkerbell.campusmarket.android.domain.model.nonfeature.error.ServerException
+import kr.linkerbell.campusmarket.android.domain.usecase.feature.myprofile.GetRecentTradeListUseCase
+import kr.linkerbell.campusmarket.android.presentation.common.base.BaseViewModel
+import kr.linkerbell.campusmarket.android.presentation.common.base.ErrorEvent
+import javax.inject.Inject
+
+@HiltViewModel
+class RecentTradeViewModel @Inject constructor(
+    private val savedStateHandle: SavedStateHandle,
+    private val getRecentTradeListUseCase: GetRecentTradeListUseCase
+) : BaseViewModel() {
+
+    private val _state: MutableStateFlow<RecentTradeState> =
+        MutableStateFlow(RecentTradeState.Init)
+    val state: StateFlow<RecentTradeState> = _state.asStateFlow()
+
+    private val _event: MutableEventFlow<RecentTradeEvent> = MutableEventFlow()
+    val event: EventFlow<RecentTradeEvent> = _event.asEventFlow()
+
+    private val _recentTrades: MutableStateFlow<PagingData<RecentTrade>> =
+        MutableStateFlow(PagingData.empty())
+    val recentTrades: StateFlow<PagingData<RecentTrade>> = _recentTrades.asStateFlow()
+
+    init {
+        launch {
+            val userId =
+                savedStateHandle.get<Long>(RecentTradeConstant.ROUTE_ARGUMENT_USER_ID) ?: -1L
+            getOtherUserTradeHistory(userId)
+        }
+    }
+
+    fun onIntent(intent: RecentTradeIntent) {
+
+    }
+
+    private suspend fun getOtherUserTradeHistory(userId: Long) {
+        getRecentTradeListUseCase(userId, type = "sales")
+            .cachedIn(viewModelScope)
+            .catch { exception ->
+                when (exception) {
+                    is ServerException -> {
+                        _errorEvent.emit(ErrorEvent.InvalidRequest(exception))
+                    }
+
+                    else -> {
+                        _errorEvent.emit(ErrorEvent.UnavailableServer(exception))
+                    }
+                }
+            }.collect {
+                _recentTrades.value = it
+            }
+    }
+}

--- a/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/trade/info/TradeInfoScreen.kt
+++ b/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/trade/info/TradeInfoScreen.kt
@@ -73,8 +73,8 @@ import kr.linkerbell.campusmarket.android.presentation.common.util.compose.safeN
 import kr.linkerbell.campusmarket.android.presentation.common.view.DialogScreen
 import kr.linkerbell.campusmarket.android.presentation.common.view.image.PostImage
 import kr.linkerbell.campusmarket.android.presentation.ui.main.home.chatroom.chat.ChatConstant
+import kr.linkerbell.campusmarket.android.presentation.ui.main.home.mypage.userprofile.UserProfileConstant
 import kr.linkerbell.campusmarket.android.presentation.ui.main.home.trade.post.TradePostConstant
-import kr.linkerbell.campusmarket.android.presentation.ui.main.home.trade.search.result.TradeSearchResultIntent
 
 @Composable
 fun TradeInfoScreen(
@@ -95,6 +95,18 @@ fun TradeInfoScreen(
 
     fun navigateToChatRoom(id: Long) {
         navController.navigate("${ChatConstant.ROUTE}/$id")
+    }
+
+    fun navigateToAuthorProfileScreen(authorId: Long) {
+        if (!isOwnerOfThisTrade) {
+            val newRoute = makeRoute(
+                route = UserProfileConstant.ROUTE,
+                arguments = mapOf(
+                    UserProfileConstant.ROUTE_ARGUMENT_USER_ID to authorId.toString()
+                )
+            )
+            navController.navigate(newRoute)
+        }
     }
 
     Scaffold(
@@ -145,7 +157,10 @@ fun TradeInfoScreen(
             )
             TradeInfoAuthor(
                 authorInfo,
-                authorNickname = tradeInfo.nickname
+                authorNickname = tradeInfo.nickname,
+                onClicked = { authorId ->
+                    navigateToAuthorProfileScreen(authorId)
+                }
             )
             TradeInfoContent(
                 title = tradeInfo.title,
@@ -344,7 +359,8 @@ private fun TradeInfoImageViewer(thumbUrl: String, imageUrls: List<String>) {
 @Composable
 private fun TradeInfoAuthor(
     authorInfo: UserProfile,
-    authorNickname: String
+    authorNickname: String,
+    onClicked: (Long) -> Unit
 ) {
     Row(
         modifier = Modifier
@@ -357,7 +373,7 @@ private fun TradeInfoAuthor(
         Row(
             modifier = Modifier
                 .clickable {
-                    //TODO(사용자 프로필 보여주는 화면으로 이동)
+                    onClicked(authorInfo.id)
                 },
             verticalAlignment = Alignment.CenterVertically
         ) {


### PR DESCRIPTION
## **설명**
- 다른 사용자 프로필 확인 UI & 로직 제작
- (마찬가지) 리뷰 목록 GET / 최근 판매 목록 GET api 완성된 후 테스트 필요

## 참고
![image](https://github.com/user-attachments/assets/d0b0520a-5008-4c18-ba74-e969cab84b59)
(예상 화면)
![image](https://github.com/user-attachments/assets/432425ac-0595-454a-8faf-fc6c5f17c29f)
(현재 확인 가능한 화면)

## 체크리스트
- [x] : 빌드 테스트를 진행하셨나요?
- [x] : 실제 기기에서 테스트를 진행하셨나요?
