### PR TITLE
[CM-18.1] 찜한 게시글을 모아보고 관리하는 페이지 UI & 로직 제작

### DIFF
--- a/data/src/main/kotlin/kr/linkerbell/campusmarket/android/data/remote/network/api/feature/MyPageApi.kt
+++ b/data/src/main/kotlin/kr/linkerbell/campusmarket/android/data/remote/network/api/feature/MyPageApi.kt
@@ -12,11 +12,11 @@ import kr.linkerbell.campusmarket.android.data.remote.network.environment.ErrorM
 import kr.linkerbell.campusmarket.android.data.remote.network.model.feature.mypage.InquiryCategoryListRes
 import kr.linkerbell.campusmarket.android.data.remote.network.model.feature.mypage.InquiryContentsReq
 import kr.linkerbell.campusmarket.android.data.remote.network.model.feature.mypage.InquiryInfoRes
+import kr.linkerbell.campusmarket.android.data.remote.network.model.feature.mypage.MyLikesRes
 import kr.linkerbell.campusmarket.android.data.remote.network.model.feature.mypage.RecentTradeRes
 import kr.linkerbell.campusmarket.android.data.remote.network.model.feature.mypage.UserInquiryListRes
 import kr.linkerbell.campusmarket.android.data.remote.network.model.feature.mypage.UserReviewRes
 import kr.linkerbell.campusmarket.android.data.remote.network.util.convert
-import timber.log.Timber
 
 class MyPageApi @Inject constructor(
     @AuthHttpClient private val client: HttpClient,
@@ -84,5 +84,15 @@ class MyPageApi @Inject constructor(
     suspend fun getInquiryInfo(qaId: Long): Result<InquiryInfoRes> {
         return client.get("$baseUrl/api/v1/answers/${qaId}")
             .convert(errorMessageMapper::map)
+    }
+
+    suspend fun getMyLikes(
+        page: Int,
+        size: Int
+    ): Result<MyLikesRes> {
+        return client.get("$baseUrl/api/v1/items/likes") {
+            parameter("page", page.toString())
+            parameter("size", size.toString())
+        }.convert<MyLikesRes>(errorMessageMapper::map)
     }
 }

--- a/data/src/main/kotlin/kr/linkerbell/campusmarket/android/data/remote/network/model/feature/mypage/MyLikesRes.kt
+++ b/data/src/main/kotlin/kr/linkerbell/campusmarket/android/data/remote/network/model/feature/mypage/MyLikesRes.kt
@@ -1,0 +1,68 @@
+package kr.linkerbell.campusmarket.android.data.remote.network.model.feature.mypage
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kr.linkerbell.campusmarket.android.data.remote.mapper.DataMapper
+import kr.linkerbell.campusmarket.android.domain.model.feature.mypage.RecentTrade
+import kr.linkerbell.campusmarket.android.domain.model.feature.trade.SummarizedTrade
+
+@Serializable
+data class MyLikesRes(
+    @SerialName("content")
+    val content: List<MyLikesContentRes>,
+    @SerialName("sort")
+    val sort: RecentTradeSortRes,
+    @SerialName("currentPage")
+    val currentPage: Int,
+    @SerialName("size")
+    val size: Int,
+    @SerialName("hasPrevious")
+    val hasPrevious: Boolean,
+    @SerialName("hasNext")
+    val hasNext: Boolean,
+)
+
+@Serializable
+data class MyLikesContentRes(
+    @SerialName("likeId")
+    val likeId: Long,
+    @SerialName("item")
+    val item: MyLikesItemRes,
+)
+
+@Serializable
+data class MyLikesItemRes(
+    @SerialName("itemId")
+    val itemId: Long,
+    @SerialName("userId")
+    val userId: Long,
+    @SerialName("nickname")
+    val nickname: String,
+    @SerialName("thumbnail")
+    val thumbnail: String,
+    @SerialName("price")
+    val price: Int,
+    @SerialName("title")
+    val title: String,
+    @SerialName("chatCount")
+    val chatCount: Int,
+    @SerialName("likeCount")
+    val likeCount: Int,
+    @SerialName("itemStatus")
+    val itemStatus: String
+) : DataMapper<SummarizedTrade> {
+    override fun toDomain(): SummarizedTrade {
+        return SummarizedTrade(
+            itemId = itemId,
+            userId = userId,
+            nickname = nickname,
+            thumbnail= thumbnail,
+            title= title,
+            price = price,
+            chatCount = chatCount,
+            likeCount = likeCount,
+            itemStatus = itemStatus,
+            isLiked = true
+        )
+    }
+}

--- a/data/src/main/kotlin/kr/linkerbell/campusmarket/android/data/remote/network/model/feature/mypage/RecentTradeRes.kt
+++ b/data/src/main/kotlin/kr/linkerbell/campusmarket/android/data/remote/network/model/feature/mypage/RecentTradeRes.kt
@@ -8,7 +8,7 @@ import kr.linkerbell.campusmarket.android.domain.model.feature.mypage.RecentTrad
 @Serializable
 data class RecentTradeRes(
     @SerialName("content")
-    val reviewList: List<RecentTradeItemRes>,
+    val content: List<RecentTradeItemRes>,
     @SerialName("sort")
     val sort: RecentTradeSortRes,
     @SerialName("currentPage")
@@ -34,7 +34,7 @@ data class RecentTradeSortRes(
 @Serializable
 data class RecentTradeItemRes(
     @SerialName("itemId")
-    val id: Long,
+    val itemId: Long,
     @SerialName("title")
     val title: String,
     @SerialName("price")
@@ -46,7 +46,7 @@ data class RecentTradeItemRes(
 ) : DataMapper<RecentTrade> {
     override fun toDomain(): RecentTrade {
         return RecentTrade(
-            id = id,
+            id = itemId,
             title = title,
             price = price,
             thumbnail = thumbnail,

--- a/data/src/main/kotlin/kr/linkerbell/campusmarket/android/data/repository/feature/mypage/RealMyPageRepository.kt
+++ b/data/src/main/kotlin/kr/linkerbell/campusmarket/android/data/repository/feature/mypage/RealMyPageRepository.kt
@@ -9,6 +9,7 @@ import kr.linkerbell.campusmarket.android.data.common.DEFAULT_PAGING_SIZE
 import kr.linkerbell.campusmarket.android.data.remote.network.api.feature.MyPageApi
 import kr.linkerbell.campusmarket.android.data.remote.network.util.toDomain
 import kr.linkerbell.campusmarket.android.data.repository.feature.mypage.paging.InquiryPagingSource
+import kr.linkerbell.campusmarket.android.data.repository.feature.mypage.paging.MyLikesPagingSource
 import kr.linkerbell.campusmarket.android.data.repository.feature.mypage.paging.RecentTradePagingSource
 import kr.linkerbell.campusmarket.android.data.repository.feature.mypage.paging.ReviewPagingSource
 import kr.linkerbell.campusmarket.android.domain.model.feature.mypage.InquiryCategoryList
@@ -16,6 +17,7 @@ import kr.linkerbell.campusmarket.android.domain.model.feature.mypage.InquiryInf
 import kr.linkerbell.campusmarket.android.domain.model.feature.mypage.RecentTrade
 import kr.linkerbell.campusmarket.android.domain.model.feature.mypage.UserInquiry
 import kr.linkerbell.campusmarket.android.domain.model.feature.mypage.UserReview
+import kr.linkerbell.campusmarket.android.domain.model.feature.trade.SummarizedTrade
 import kr.linkerbell.campusmarket.android.domain.repository.feature.MyPageRepository
 
 class RealMyPageRepository @Inject constructor(
@@ -84,5 +86,19 @@ class RealMyPageRepository @Inject constructor(
 
     override suspend fun getInquiryInfo(qaId: Long): Result<InquiryInfo> {
         return myPageApi.getInquiryInfo(qaId).toDomain()
+    }
+
+    override suspend fun getMyLikes(): Flow<PagingData<SummarizedTrade>> {
+        return Pager(
+            config = PagingConfig(
+                pageSize = DEFAULT_PAGING_SIZE,
+                enablePlaceholders = true
+            ),
+            pagingSourceFactory = {
+                MyLikesPagingSource(
+                    myPageApi = myPageApi
+                )
+            },
+        ).flow
     }
 }

--- a/data/src/main/kotlin/kr/linkerbell/campusmarket/android/data/repository/feature/mypage/paging/MyLikesPagingSource.kt
+++ b/data/src/main/kotlin/kr/linkerbell/campusmarket/android/data/repository/feature/mypage/paging/MyLikesPagingSource.kt
@@ -4,36 +4,32 @@ import androidx.paging.PagingSource
 import androidx.paging.PagingState
 import kr.linkerbell.campusmarket.android.data.common.DEFAULT_PAGE_START
 import kr.linkerbell.campusmarket.android.data.remote.network.api.feature.MyPageApi
-import kr.linkerbell.campusmarket.android.domain.model.feature.mypage.RecentTrade
+import kr.linkerbell.campusmarket.android.domain.model.feature.trade.SummarizedTrade
 
-class RecentTradePagingSource(
-    private val myPageApi: MyPageApi,
-    private val userId: Long,
-    private val type: String
-) : PagingSource<Int, RecentTrade>() {
+class MyLikesPagingSource(
+    private val myPageApi: MyPageApi
+) : PagingSource<Int, SummarizedTrade>() {
 
-    override fun getRefreshKey(state: PagingState<Int, RecentTrade>): Int? {
+    override fun getRefreshKey(state: PagingState<Int, SummarizedTrade>): Int? {
         return state.anchorPosition?.let { anchorPosition ->
             state.closestPageToPosition(anchorPosition)?.prevKey?.plus(1)
                 ?: state.closestPageToPosition(anchorPosition)?.nextKey?.minus(1)
         }
     }
 
-    override suspend fun load(params: LoadParams<Int>): LoadResult<Int, RecentTrade> {
+    override suspend fun load(params: LoadParams<Int>): LoadResult<Int, SummarizedTrade> {
         val pageNum = params.key ?: DEFAULT_PAGE_START
         val pageSize = params.loadSize
 
-        return myPageApi.getRecentTrade(
-            userId = userId,
+        return myPageApi.getMyLikes(
             page = pageNum,
-            size = pageSize,
-            type = type
+            size = pageSize
         ).map { data ->
             val nextPage = if (data.hasNext) pageNum + 1 else null
             val previousPage = if (data.hasPrevious) pageNum - 1 else null
 
             LoadResult.Page(
-                data = data.content.map { it.toDomain() },
+                data = data.content.map { it.item.toDomain() },
                 prevKey = previousPage,
                 nextKey = nextPage
             )

--- a/domain/src/main/kotlin/kr/linkerbell/campusmarket/android/domain/repository/feature/MyPageRepository.kt
+++ b/domain/src/main/kotlin/kr/linkerbell/campusmarket/android/domain/repository/feature/MyPageRepository.kt
@@ -7,6 +7,7 @@ import kr.linkerbell.campusmarket.android.domain.model.feature.mypage.InquiryInf
 import kr.linkerbell.campusmarket.android.domain.model.feature.mypage.RecentTrade
 import kr.linkerbell.campusmarket.android.domain.model.feature.mypage.UserInquiry
 import kr.linkerbell.campusmarket.android.domain.model.feature.mypage.UserReview
+import kr.linkerbell.campusmarket.android.domain.model.feature.trade.SummarizedTrade
 
 interface MyPageRepository {
 
@@ -18,6 +19,8 @@ interface MyPageRepository {
         userId: Long,
         type: String
     ): Flow<PagingData<RecentTrade>>
+
+    suspend fun getMyLikes(): Flow<PagingData<SummarizedTrade>>
 
     suspend fun getInquiryCategoryList(): Result<InquiryCategoryList>
 

--- a/domain/src/main/kotlin/kr/linkerbell/campusmarket/android/domain/usecase/feature/myprofile/GetMyLikesUseCase.kt
+++ b/domain/src/main/kotlin/kr/linkerbell/campusmarket/android/domain/usecase/feature/myprofile/GetMyLikesUseCase.kt
@@ -1,0 +1,16 @@
+package kr.linkerbell.campusmarket.android.domain.usecase.feature.myprofile
+
+import androidx.paging.PagingData
+import javax.inject.Inject
+import kotlinx.coroutines.flow.Flow
+import kr.linkerbell.campusmarket.android.domain.model.feature.trade.SummarizedTrade
+import kr.linkerbell.campusmarket.android.domain.repository.feature.MyPageRepository
+
+class GetMyLikesUseCase @Inject constructor(
+    private val myPageRepository: MyPageRepository
+) {
+    suspend operator fun invoke(
+    ): Flow<PagingData<SummarizedTrade>> {
+        return myPageRepository.getMyLikes()
+    }
+}

--- a/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/MainDestination.kt
+++ b/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/MainDestination.kt
@@ -9,6 +9,7 @@ import kr.linkerbell.campusmarket.android.presentation.ui.main.home.mypage.inqui
 import kr.linkerbell.campusmarket.android.presentation.ui.main.home.mypage.inquiry.inquiryDestination
 import kr.linkerbell.campusmarket.android.presentation.ui.main.home.mypage.inquiry.post.inquiryPostDestination
 import kr.linkerbell.campusmarket.android.presentation.ui.main.home.mypage.inquiry.view.inquiryViewDestination
+import kr.linkerbell.campusmarket.android.presentation.ui.main.home.mypage.likes.myLikesDestination
 import kr.linkerbell.campusmarket.android.presentation.ui.main.home.mypage.logout.logoutDestination
 import kr.linkerbell.campusmarket.android.presentation.ui.main.home.mypage.logout.withdrawal.withdrawalDestination
 import kr.linkerbell.campusmarket.android.presentation.ui.main.home.mypage.rating.ratingDestination
@@ -55,4 +56,5 @@ fun NavGraphBuilder.mainDestination(
     myRecentReviewDestination(navController = navController)
     inquiryViewDestination(navController = navController)
     inquiryInfoDestination(navController = navController)
+    myLikesDestination(navController = navController)
 }

--- a/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/mypage/MyPageScreen.kt
+++ b/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/mypage/MyPageScreen.kt
@@ -59,6 +59,7 @@ import kr.linkerbell.campusmarket.android.presentation.common.util.compose.safeN
 import kr.linkerbell.campusmarket.android.presentation.common.view.RippleBox
 import kr.linkerbell.campusmarket.android.presentation.common.view.image.PostImage
 import kr.linkerbell.campusmarket.android.presentation.ui.main.home.mypage.changecampus.ChangeCampusConstant
+import kr.linkerbell.campusmarket.android.presentation.ui.main.home.mypage.likes.MyLikesConstant
 import kr.linkerbell.campusmarket.android.presentation.ui.main.home.mypage.logout.LogoutConstant
 import kr.linkerbell.campusmarket.android.presentation.ui.main.home.mypage.recent_review.MyRecentReviewConstant
 import kr.linkerbell.campusmarket.android.presentation.ui.main.home.mypage.recent_trade.MyRecentTradeConstant
@@ -266,6 +267,7 @@ fun MyPageScreen(
                                 )
                             )
                             navController.safeNavigate(newRoute)
+                            navController.safeNavigate(MyLikesConstant.ROUTE)
                         },
                     verticalAlignment = Alignment.CenterVertically
                 ) {
@@ -287,7 +289,7 @@ fun MyPageScreen(
                         .padding(8.dp)
                         .fillMaxWidth()
                         .clickable {
-                            //찜한 목록으로 이동
+                            navController.safeNavigate(MyLikesConstant.ROUTE)
                         },
                     verticalAlignment = Alignment.CenterVertically
                 ) {

--- a/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/mypage/MyPageScreen.kt
+++ b/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/mypage/MyPageScreen.kt
@@ -267,7 +267,6 @@ fun MyPageScreen(
                                 )
                             )
                             navController.safeNavigate(newRoute)
-                            navController.safeNavigate(MyLikesConstant.ROUTE)
                         },
                     verticalAlignment = Alignment.CenterVertically
                 ) {

--- a/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/mypage/likes/MyLikesArgument.kt
+++ b/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/mypage/likes/MyLikesArgument.kt
@@ -1,0 +1,23 @@
+package kr.linkerbell.campusmarket.android.presentation.ui.main.home.mypage.likes
+
+import androidx.compose.runtime.Immutable
+import kotlin.coroutines.CoroutineContext
+import kr.linkerbell.campusmarket.android.common.util.coroutine.event.EventFlow
+
+@Immutable
+data class MyLikesArgument(
+    val state: MyLikesState,
+    val event: EventFlow<MyLikesEvent>,
+    val intent: (MyLikesIntent) -> Unit,
+    val logEvent: (eventName: String, params: Map<String, Any>) -> Unit,
+    val coroutineContext: CoroutineContext
+)
+
+sealed interface MyLikesState {
+    data object Init : MyLikesState
+    data object Loading : MyLikesState
+}
+
+sealed interface MyLikesEvent
+
+sealed interface MyLikesIntent

--- a/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/mypage/likes/MyLikesConstant.kt
+++ b/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/mypage/likes/MyLikesConstant.kt
@@ -1,0 +1,7 @@
+package kr.linkerbell.campusmarket.android.presentation.ui.main.home.mypage.likes
+
+import kr.linkerbell.campusmarket.android.presentation.ui.main.home.mypage.MyPageConstant
+
+object MyLikesConstant {
+    const val ROUTE = "${MyPageConstant.ROUTE}/myLikes"
+}

--- a/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/mypage/likes/MyLikesData.kt
+++ b/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/mypage/likes/MyLikesData.kt
@@ -1,0 +1,10 @@
+package kr.linkerbell.campusmarket.android.presentation.ui.main.home.mypage.likes
+
+import androidx.compose.runtime.Immutable
+import androidx.paging.compose.LazyPagingItems
+import kr.linkerbell.campusmarket.android.domain.model.feature.trade.SummarizedTrade
+
+@Immutable
+data class MyLikesData(
+    val myLikes: LazyPagingItems<SummarizedTrade>
+)

--- a/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/mypage/likes/MyLikesDestination.kt
+++ b/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/mypage/likes/MyLikesDestination.kt
@@ -1,0 +1,47 @@
+package kr.linkerbell.campusmarket.android.presentation.ui.main.home.mypage.likes
+
+import androidx.compose.runtime.getValue
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.navigation.NavController
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.compose.composable
+import androidx.paging.compose.collectAsLazyPagingItems
+import kr.linkerbell.campusmarket.android.presentation.common.util.compose.ErrorObserver
+
+fun NavGraphBuilder.myLikesDestination(
+    navController: NavController
+) {
+    composable(
+        route = MyLikesConstant.ROUTE,
+    ) {
+        val viewModel: MyLikesViewModel = hiltViewModel()
+
+        val argument: MyLikesArgument = let {
+            val state by viewModel.state.collectAsStateWithLifecycle()
+
+            MyLikesArgument(
+                state = state,
+                event = viewModel.event,
+                intent = viewModel::onIntent,
+                logEvent = viewModel::logEvent,
+                coroutineContext = viewModel.coroutineContext
+            )
+        }
+
+        val data: MyLikesData = let {
+            val myLikes = viewModel.myLikes.collectAsLazyPagingItems()
+
+            MyLikesData(
+                myLikes = myLikes
+            )
+        }
+
+        ErrorObserver(viewModel)
+        MyLikesScreen(
+            navController = navController,
+            argument = argument,
+            data = data
+        )
+    }
+}

--- a/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/mypage/likes/MyLikesScreen.kt
+++ b/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/mypage/likes/MyLikesScreen.kt
@@ -1,0 +1,323 @@
+package kr.linkerbell.campusmarket.android.presentation.ui.main.home.mypage.likes
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material.icons.filled.FavoriteBorder
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Color.Companion.LightGray
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.constraintlayout.compose.ConstraintLayout
+import androidx.constraintlayout.compose.Dimension
+import androidx.navigation.NavController
+import androidx.navigation.compose.rememberNavController
+import androidx.paging.PagingData
+import androidx.paging.compose.LazyPagingItems
+import androidx.paging.compose.collectAsLazyPagingItems
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.plus
+import kr.linkerbell.campusmarket.android.common.util.coroutine.event.MutableEventFlow
+import kr.linkerbell.campusmarket.android.domain.model.feature.trade.SummarizedTrade
+import kr.linkerbell.campusmarket.android.presentation.R
+import kr.linkerbell.campusmarket.android.presentation.common.theme.Blue200
+import kr.linkerbell.campusmarket.android.presentation.common.theme.Blue400
+import kr.linkerbell.campusmarket.android.presentation.common.theme.Body1
+import kr.linkerbell.campusmarket.android.presentation.common.theme.Caption2
+import kr.linkerbell.campusmarket.android.presentation.common.theme.Gray200
+import kr.linkerbell.campusmarket.android.presentation.common.theme.Gray600
+import kr.linkerbell.campusmarket.android.presentation.common.theme.Headline2
+import kr.linkerbell.campusmarket.android.presentation.common.theme.Headline3
+import kr.linkerbell.campusmarket.android.presentation.common.theme.Space56
+import kr.linkerbell.campusmarket.android.presentation.common.theme.White
+import kr.linkerbell.campusmarket.android.presentation.common.util.compose.isEmpty
+import kr.linkerbell.campusmarket.android.presentation.common.util.compose.makeRoute
+import kr.linkerbell.campusmarket.android.presentation.common.util.compose.safeNavigateUp
+import kr.linkerbell.campusmarket.android.presentation.common.view.RippleBox
+import kr.linkerbell.campusmarket.android.presentation.common.view.image.PostImage
+import kr.linkerbell.campusmarket.android.presentation.ui.main.home.trade.info.TradeInfoConstant
+
+@Composable
+fun MyLikesScreen(
+    navController: NavController,
+    argument: MyLikesArgument,
+    data: MyLikesData
+) {
+    val (state, event, intent, logEvent, coroutineContext) = argument
+    val scope = rememberCoroutineScope() + coroutineContext
+
+    val myLikes by remember { mutableStateOf(data.myLikes) }
+
+    fun onItemClicked(tradeId: Long) {
+        val tradeInfoRoute = makeRoute(
+            route = TradeInfoConstant.ROUTE,
+            arguments = mapOf(
+                TradeInfoConstant.ROUTE_ARGUMENT_ITEM_ID to tradeId.toString()
+            )
+        )
+        navController.navigate(tradeInfoRoute)
+    }
+
+    ConstraintLayout(
+        modifier = Modifier
+            .background(White)
+            .fillMaxSize()
+    ) {
+        val (topBar, contents) = createRefs()
+        Row(
+            modifier = Modifier
+                .height(Space56)
+                .fillMaxWidth()
+                .constrainAs(topBar) {
+                    top.linkTo(parent.top)
+                    start.linkTo(parent.start)
+                    end.linkTo(parent.end)
+                },
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            RippleBox(
+                modifier = Modifier
+                    .padding(4.dp),
+                onClick = {
+                    navController.safeNavigateUp()
+                }
+            ) {
+                Icon(
+                    painter = painterResource(R.drawable.ic_chevron_left),
+                    contentDescription = "Navigate Up Button",
+                    modifier = Modifier
+                        .size(48.dp)
+                        .padding(horizontal = 8.dp)
+                )
+            }
+            Text(
+                text = "찜한 목록",
+                style = Headline2
+            )
+        }
+        Column(
+            modifier = Modifier
+                .padding(vertical = 8.dp)
+                .constrainAs(contents) {
+                    top.linkTo(topBar.bottom)
+                    start.linkTo(parent.start)
+                    end.linkTo(parent.end)
+                    bottom.linkTo(parent.bottom)
+                    width = Dimension.fillToConstraints
+                    height = Dimension.fillToConstraints
+                }
+        ) {
+            MyRecentTradeListScreen(
+                myLikes = myLikes,
+                onItemClicked = { itemId ->
+                    onItemClicked(itemId)
+                }
+            )
+        }
+    }
+}
+
+@Composable
+private fun MyRecentTradeListScreen(
+    myLikes: LazyPagingItems<SummarizedTrade>,
+    onItemClicked: (Long) -> Unit
+) {
+    if (myLikes.isEmpty()) {
+        Box(
+            modifier = Modifier.fillMaxWidth(),
+            contentAlignment = Alignment.Center
+        ) {
+            Text(
+                text = "보여줄 항목이 없어요",
+                style = Caption2,
+                color = Gray600,
+                modifier = Modifier.padding(start = 8.dp, top = 8.dp)
+            )
+        }
+    }
+    HorizontalDivider(
+        thickness = 1.dp,
+        color = Gray200,
+        modifier = Modifier.padding(horizontal = 2.dp)
+    )
+    LazyColumn {
+        items(
+            count = myLikes.itemCount,
+            key = { index -> myLikes[index]?.itemId ?: -1 }
+        ) { index ->
+            val trade = myLikes[index] ?: return@items
+            TradeItemCard(
+                item = trade,
+                onItemCardClicked = {
+                    onItemClicked(trade.itemId)
+                }
+            )
+        }
+    }
+}
+
+@Composable
+private fun TradeItemCard(
+    item: SummarizedTrade,
+    onItemCardClicked: (Long) -> Unit
+) {
+    Box(
+        Modifier
+            .shadow(4.dp)
+            .clip(RoundedCornerShape(5.dp))
+            .clickable {
+                onItemCardClicked(item.itemId)
+            }
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(Color.White)
+                .padding(8.dp),
+        ) {
+            PostImage(
+                data = item.thumbnail,
+                modifier = Modifier
+                    .size(100.dp)
+                    .clip(RoundedCornerShape(8.dp))
+            )
+            Column(
+                modifier = Modifier.padding(start = 10.dp)
+            ) {
+                Text(
+                    text = item.title,
+                    style = Headline3,
+                    overflow = TextOverflow.Ellipsis,
+                    maxLines = 1,
+                    modifier = Modifier.padding(bottom = 4.dp),
+                )
+
+                Text(
+                    text = item.nickname,
+                    style = Caption2,
+                    modifier = Modifier.padding(bottom = 4.dp)
+                )
+                Text(
+                    text = "${item.chatCount} 명이 대화중",
+                    style = Caption2,
+                    modifier = Modifier.padding(bottom = 4.dp)
+                )
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .widthIn(min = 100.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.SpaceBetween
+                ) {
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        TradeItemStatus(isSold = item.itemStatus == "SOLDOUT")
+                        Text(
+                            text = "${item.price} 원",
+                            overflow = TextOverflow.Ellipsis,
+                            modifier = Modifier.padding(4.dp)
+                        )
+                    }
+                    Row(
+                        modifier = Modifier.padding(start = 8.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        val favIcon =
+                            if (item.isLiked) Icons.Default.Favorite else Icons.Default.FavoriteBorder
+                        Icon(
+                            imageVector = favIcon,
+                            tint = Blue400,
+                            contentDescription = "isLike",
+                            modifier = Modifier.size(12.dp)
+                        )
+                        Spacer(modifier = Modifier.padding(2.dp))
+                        Text(item.likeCount.toString())
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun TradeItemStatus(isSold: Boolean) {
+    val backgroundColor = if (isSold) LightGray else Blue200
+    val text = if (isSold) "거래 완료" else "거래 가능"
+
+    Box(
+        modifier = Modifier
+            .clip(RoundedCornerShape(5.dp))
+            .background(backgroundColor),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(
+            text = text,
+            style = Body1,
+            color = White,
+            modifier = Modifier.padding(horizontal = 4.dp, vertical = 2.dp)
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun MyLikesScreenPreview() {
+    MyLikesScreen(
+        navController = rememberNavController(),
+        argument = MyLikesArgument(
+            state = MyLikesState.Init,
+            event = MutableEventFlow(),
+            intent = {},
+            logEvent = { _, _ -> },
+            coroutineContext = Dispatchers.IO
+        ),
+        data = MyLikesData(
+            myLikes = MutableStateFlow(
+                PagingData.from(
+                    listOf(
+                        SummarizedTrade(
+                            itemId = 1L,
+                            userId = 1L,
+                            nickname = "장성혁",
+                            thumbnail = "https://picsum.photos/200",
+                            title = "콜라 팝니다",
+                            price = 1000,
+                            chatCount = 5,
+                            likeCount = 2,
+                            itemStatus = "",
+                            isLiked = true
+                        )
+                    )
+                )
+            ).collectAsLazyPagingItems()
+        )
+    )
+}

--- a/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/mypage/likes/MyLikesViewModel.kt
+++ b/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/mypage/likes/MyLikesViewModel.kt
@@ -1,0 +1,66 @@
+package kr.linkerbell.campusmarket.android.presentation.ui.main.home.mypage.likes
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.viewModelScope
+import androidx.paging.PagingData
+import androidx.paging.cachedIn
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.catch
+import kr.linkerbell.campusmarket.android.common.util.coroutine.event.EventFlow
+import kr.linkerbell.campusmarket.android.common.util.coroutine.event.MutableEventFlow
+import kr.linkerbell.campusmarket.android.common.util.coroutine.event.asEventFlow
+import kr.linkerbell.campusmarket.android.domain.model.feature.trade.SummarizedTrade
+import kr.linkerbell.campusmarket.android.domain.model.nonfeature.error.ServerException
+import kr.linkerbell.campusmarket.android.domain.usecase.feature.myprofile.GetMyLikesUseCase
+import kr.linkerbell.campusmarket.android.presentation.common.base.BaseViewModel
+import kr.linkerbell.campusmarket.android.presentation.common.base.ErrorEvent
+import kr.linkerbell.campusmarket.android.presentation.ui.main.home.mypage.userprofile.recent_trade.RecentTradeConstant
+
+@HiltViewModel
+class MyLikesViewModel @Inject constructor(
+    private val savedStateHandle: SavedStateHandle,
+    private val getMyLikesUseCase: GetMyLikesUseCase
+) : BaseViewModel() {
+
+    private val _state: MutableStateFlow<MyLikesState> = MutableStateFlow(MyLikesState.Init)
+    val state: StateFlow<MyLikesState> = _state.asStateFlow()
+
+    private val _event: MutableEventFlow<MyLikesEvent> = MutableEventFlow()
+    val event: EventFlow<MyLikesEvent> = _event.asEventFlow()
+
+    private val _myLikes: MutableStateFlow<PagingData<SummarizedTrade>> =
+        MutableStateFlow(PagingData.empty())
+    val myLikes: StateFlow<PagingData<SummarizedTrade>> =
+        _myLikes.asStateFlow()
+
+    fun onIntent(intent: MyLikesIntent) {
+
+    }
+
+    init {
+        launch {
+            getMyLikes()
+        }
+    }
+
+    private suspend fun getMyLikes() {
+        getMyLikesUseCase().cachedIn(viewModelScope)
+            .catch { exception ->
+                when (exception) {
+                    is ServerException -> {
+                        _errorEvent.emit(ErrorEvent.InvalidRequest(exception))
+                    }
+
+                    else -> {
+                        _errorEvent.emit(ErrorEvent.UnavailableServer(exception))
+                    }
+                }
+            }.collect {
+                _myLikes.value = it
+            }
+    }
+}


### PR DESCRIPTION
- feature

## **설명**
- 찜한 게시글을 모아보고 관리하는 페이지 UI & 로직 제작

## 참고
![image](https://github.com/user-attachments/assets/b020e239-1912-4fb1-9cb6-eaddb7f30481)


## 체크리스트
- [x] : 빌드 테스트를 진행하셨나요?
- [x] : 실제 기기에서 테스트를 진행하셨나요?
