### PR TITLE
[CM-31.1] 사용자 프로필 수정 페이지 UI & 로직 제작

### DIFF
--- a/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/MainDestination.kt
+++ b/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/MainDestination.kt
@@ -4,6 +4,7 @@ import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import kr.linkerbell.campusmarket.android.presentation.ui.main.home.chatroom.chat.chatDestination
 import kr.linkerbell.campusmarket.android.presentation.ui.main.home.homeDestination
+import kr.linkerbell.campusmarket.android.presentation.ui.main.home.mypage.change_profile.changeProfileDestination
 import kr.linkerbell.campusmarket.android.presentation.ui.main.home.mypage.changecampus.changeCampusDestination
 import kr.linkerbell.campusmarket.android.presentation.ui.main.home.mypage.inquiry.info.inquiryInfoDestination
 import kr.linkerbell.campusmarket.android.presentation.ui.main.home.mypage.inquiry.inquiryDestination
@@ -57,4 +58,5 @@ fun NavGraphBuilder.mainDestination(
     inquiryViewDestination(navController = navController)
     inquiryInfoDestination(navController = navController)
     myLikesDestination(navController = navController)
+    changeProfileDestination(navController = navController)
 }

--- a/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/mypage/MyPageScreen.kt
+++ b/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/mypage/MyPageScreen.kt
@@ -54,11 +54,14 @@ import kr.linkerbell.campusmarket.android.presentation.common.theme.Space24
 import kr.linkerbell.campusmarket.android.presentation.common.theme.Space56
 import kr.linkerbell.campusmarket.android.presentation.common.theme.White
 import kr.linkerbell.campusmarket.android.presentation.common.util.compose.ErrorObserver
+import kr.linkerbell.campusmarket.android.presentation.common.util.compose.LaunchedEffectWithLifecycle
 import kr.linkerbell.campusmarket.android.presentation.common.util.compose.makeRoute
 import kr.linkerbell.campusmarket.android.presentation.common.util.compose.safeNavigate
 import kr.linkerbell.campusmarket.android.presentation.common.view.RippleBox
 import kr.linkerbell.campusmarket.android.presentation.common.view.image.PostImage
+import kr.linkerbell.campusmarket.android.presentation.ui.main.home.mypage.change_profile.ChangeProfileConstant
 import kr.linkerbell.campusmarket.android.presentation.ui.main.home.mypage.changecampus.ChangeCampusConstant
+import kr.linkerbell.campusmarket.android.presentation.ui.main.home.mypage.inquiry.InquiryConstant
 import kr.linkerbell.campusmarket.android.presentation.ui.main.home.mypage.likes.MyLikesConstant
 import kr.linkerbell.campusmarket.android.presentation.ui.main.home.mypage.logout.LogoutConstant
 import kr.linkerbell.campusmarket.android.presentation.ui.main.home.mypage.recent_review.MyRecentReviewConstant
@@ -179,7 +182,7 @@ fun MyPageScreen(
                         .padding(8.dp)
                         .fillMaxWidth()
                         .clickable {
-                            //프로필 설정 페이지로 이동
+                            navController.safeNavigate(ChangeProfileConstant.ROUTE)
                         },
                     verticalAlignment = Alignment.CenterVertically
                 ) {
@@ -336,12 +339,28 @@ fun MyPageScreen(
                         modifier = Modifier.padding(start = 8.dp)
                     )
                 }
-                Text(
-                    text = "문의",
-                    style = Headline3,
-                    color = Black,
-                    modifier = Modifier.padding(start = 8.dp)
-                )
+                Row(
+                    modifier = Modifier
+                        .padding(8.dp)
+                        .fillMaxWidth()
+                        .clickable {
+                            navController.safeNavigate(InquiryConstant.ROUTE)
+                        },
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Icon(
+                        modifier = Modifier.size(16.dp),
+                        painter = painterResource(R.drawable.ic_list),
+                        contentDescription = null,
+                        tint = Blue400
+                    )
+                    Text(
+                        text = "문의",
+                        style = Headline3,
+                        color = Black,
+                        modifier = Modifier.padding(start = 8.dp)
+                    )
+                }
             }
             Row(
                 modifier = Modifier
@@ -389,8 +408,10 @@ fun MyPageScreen(
             }
         }
     }
+    LaunchedEffectWithLifecycle(event, coroutineContext) {
+        argument.intent(MyPageIntent.RefreshData)
+    }
 }
-
 
 @Composable
 private fun MyProfileUserInfo(
@@ -441,7 +462,6 @@ private fun MyProfileUserInfo(
         }
     }
 }
-
 
 @Preview
 @Composable

--- a/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/mypage/change_profile/ChangeProfileArgument.kt
+++ b/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/mypage/change_profile/ChangeProfileArgument.kt
@@ -1,0 +1,32 @@
+package kr.linkerbell.campusmarket.android.presentation.ui.main.home.mypage.change_profile
+
+import androidx.compose.runtime.Immutable
+import kotlin.coroutines.CoroutineContext
+import kr.linkerbell.campusmarket.android.common.util.coroutine.event.EventFlow
+import kr.linkerbell.campusmarket.android.presentation.model.gallery.GalleryImage
+
+@Immutable
+data class ChangeProfileArgument(
+    val state: ChangeProfileState,
+    val event: EventFlow<ChangeProfileEvent>,
+    val intent: (ChangeProfileIntent) -> Unit,
+    val logEvent: (eventName: String, params: Map<String, Any>) -> Unit,
+    val coroutineContext: CoroutineContext
+)
+
+sealed interface ChangeProfileState {
+    data object Init : ChangeProfileState
+    data object Loading : ChangeProfileState
+}
+
+sealed interface ChangeProfileEvent {
+    sealed interface SetProfile : ChangeProfileEvent {
+        data object Success : SetProfile
+    }
+}
+
+sealed interface ChangeProfileIntent {
+    data object RefreshProfile : ChangeProfileIntent
+    data class OnChangeNickname(val nickname: String) : ChangeProfileIntent
+    data class OnChangeProfileImage(val image: GalleryImage?) : ChangeProfileIntent
+}

--- a/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/mypage/change_profile/ChangeProfileConstant.kt
+++ b/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/mypage/change_profile/ChangeProfileConstant.kt
@@ -1,0 +1,7 @@
+package kr.linkerbell.campusmarket.android.presentation.ui.main.home.mypage.change_profile
+
+import kr.linkerbell.campusmarket.android.presentation.ui.main.home.mypage.MyPageConstant
+
+object ChangeProfileConstant {
+    const val ROUTE: String = "${MyPageConstant.ROUTE}/changeProfile"
+}

--- a/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/mypage/change_profile/ChangeProfileData.kt
+++ b/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/mypage/change_profile/ChangeProfileData.kt
@@ -1,0 +1,9 @@
+package kr.linkerbell.campusmarket.android.presentation.ui.main.home.mypage.change_profile
+
+import androidx.compose.runtime.Immutable
+import kr.linkerbell.campusmarket.android.domain.model.nonfeature.user.MyProfile
+
+@Immutable
+data class ChangeProfileData(
+    val myProfile: MyProfile
+)

--- a/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/mypage/change_profile/ChangeProfileDestination.kt
+++ b/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/mypage/change_profile/ChangeProfileDestination.kt
@@ -1,0 +1,46 @@
+package kr.linkerbell.campusmarket.android.presentation.ui.main.home.mypage.change_profile
+
+import androidx.compose.runtime.getValue
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.navigation.NavController
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.compose.composable
+import kr.linkerbell.campusmarket.android.presentation.common.util.compose.ErrorObserver
+
+fun NavGraphBuilder.changeProfileDestination(
+    navController: NavController
+) {
+    composable(
+        route = ChangeProfileConstant.ROUTE,
+    ) {
+        val viewModel: ChangeProfileViewModel = hiltViewModel()
+
+        val argument: ChangeProfileArgument = let {
+            val state by viewModel.state.collectAsStateWithLifecycle()
+
+            ChangeProfileArgument(
+                state = state,
+                event = viewModel.event,
+                intent = viewModel::onIntent,
+                logEvent = viewModel::logEvent,
+                coroutineContext = viewModel.coroutineContext
+            )
+        }
+
+        val data: ChangeProfileData = let {
+            val userProfile by viewModel.myProfile.collectAsStateWithLifecycle()
+
+            ChangeProfileData(
+                myProfile = userProfile
+            )
+        }
+
+        ErrorObserver(viewModel)
+        ChangeProfileScreen(
+            navController = navController,
+            argument = argument,
+            data = data
+        )
+    }
+}

--- a/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/mypage/change_profile/ChangeProfileScreen.kt
+++ b/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/mypage/change_profile/ChangeProfileScreen.kt
@@ -1,0 +1,295 @@
+package kr.linkerbell.campusmarket.android.presentation.ui.main.home.mypage.change_profile
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CardDefaults.cardElevation
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.constraintlayout.compose.ConstraintLayout
+import androidx.constraintlayout.compose.Dimension
+import androidx.navigation.NavController
+import androidx.navigation.compose.rememberNavController
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.plus
+import kr.linkerbell.campusmarket.android.common.util.coroutine.event.MutableEventFlow
+import kr.linkerbell.campusmarket.android.common.util.coroutine.event.eventObserve
+import kr.linkerbell.campusmarket.android.domain.model.nonfeature.user.MyProfile
+import kr.linkerbell.campusmarket.android.presentation.R
+import kr.linkerbell.campusmarket.android.presentation.common.theme.Black
+import kr.linkerbell.campusmarket.android.presentation.common.theme.Blue400
+import kr.linkerbell.campusmarket.android.presentation.common.theme.Gray200
+import kr.linkerbell.campusmarket.android.presentation.common.theme.Gray900
+import kr.linkerbell.campusmarket.android.presentation.common.theme.Headline2
+import kr.linkerbell.campusmarket.android.presentation.common.theme.Space20
+import kr.linkerbell.campusmarket.android.presentation.common.theme.Space56
+import kr.linkerbell.campusmarket.android.presentation.common.theme.White
+import kr.linkerbell.campusmarket.android.presentation.common.util.compose.LaunchedEffectWithLifecycle
+import kr.linkerbell.campusmarket.android.presentation.common.util.compose.safeNavigateUp
+import kr.linkerbell.campusmarket.android.presentation.common.view.DialogScreen
+import kr.linkerbell.campusmarket.android.presentation.common.view.RippleBox
+import kr.linkerbell.campusmarket.android.presentation.common.view.image.PostImage
+import kr.linkerbell.campusmarket.android.presentation.common.view.textfield.TypingTextField
+import kr.linkerbell.campusmarket.android.presentation.model.gallery.GalleryImage
+import kr.linkerbell.campusmarket.android.presentation.ui.main.common.gallery.GalleryScreen
+
+@Composable
+fun ChangeProfileScreen(
+    navController: NavController,
+    argument: ChangeProfileArgument,
+    data: ChangeProfileData
+) {
+    val (state, event, intent, logEvent, coroutineContext) = argument
+    val scope = rememberCoroutineScope() + coroutineContext
+
+    val focusRequester = remember { FocusRequester() }
+
+    val originalProfileImage = data.myProfile.profileImage
+    val originalNickname = data.myProfile.nickname
+    var newProfileImage: GalleryImage? by rememberSaveable { mutableStateOf(null) }
+    var newNickname = data.myProfile.nickname
+
+    val isNicknameSizeValid = newNickname.toByteArray(Charsets.UTF_8).size in 0..20
+    val isNicknameFormValid = newNickname.matches("[a-zA-Zㄱ-ㅎㅏ-ㅣ가-힣0-9]*".toRegex())
+
+    var isSuccessDialogVisible by remember { mutableStateOf(false) }
+    var isGalleryShowing by remember { mutableStateOf(false) }
+
+    fun nicknameValidation(): Boolean {
+        return newNickname.isNotBlank()
+                && isNicknameSizeValid
+                && isNicknameFormValid
+                && (newNickname != originalNickname)
+    }
+
+    if (isSuccessDialogVisible) {
+        DialogScreen(
+            title = "등록 성공!",
+            message = "프로필이 변경되었습니다.",
+            isCancelable = false,
+            onDismissRequest = {
+                isSuccessDialogVisible = false
+                navController.safeNavigateUp()
+            }
+        )
+    }
+
+    if (isGalleryShowing) {
+        GalleryScreen(
+            navController = navController,
+            onDismissRequest = { isGalleryShowing = false },
+            onResult = {
+                newProfileImage = it.getOrNull(0)
+            }
+        )
+    }
+
+    ConstraintLayout(
+        modifier = Modifier
+            .background(White)
+            .fillMaxSize()
+    ) {
+        val (topBar, contents, button) = createRefs()
+        Row(
+            modifier = Modifier
+                .height(Space56)
+                .fillMaxWidth()
+                .constrainAs(topBar) {
+                    top.linkTo(parent.top)
+                    start.linkTo(parent.start)
+                    end.linkTo(parent.end)
+                },
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                RippleBox(
+                    onClick = {
+                        navController.safeNavigateUp()
+                    }
+                ) {
+                    Icon(
+                        painter = painterResource(R.drawable.ic_chevron_left),
+                        contentDescription = "Navigate Up Button",
+                        modifier = Modifier
+                            .size(40.dp)
+                            .padding(horizontal = 8.dp)
+                    )
+                }
+                Text(
+                    text = "프로필 수정",
+                    style = Headline2.merge(Gray900),
+                    color = Black
+                )
+            }
+        }
+        Column(
+            modifier = Modifier
+                .padding(16.dp)
+                .verticalScroll(rememberScrollState())
+                .constrainAs(contents) {
+                    top.linkTo(topBar.bottom)
+                    start.linkTo(parent.start)
+                    end.linkTo(parent.end)
+                    bottom.linkTo(parent.bottom)
+                    width = Dimension.fillToConstraints
+                    height = Dimension.fillToConstraints
+                }
+        ) {
+            Column(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                Card(
+                    modifier = Modifier.size(150.dp),
+                    shape = CircleShape,
+                    colors = CardDefaults.cardColors(White),
+                    elevation = cardElevation(0.dp, 0.dp, 0.dp, 0.dp, 0.dp, 0.dp),
+                    border = BorderStroke(3.dp, Blue400)
+                ) {
+                    PostImage(
+                        data = newProfileImage ?: originalProfileImage,
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .clickable {
+                                isGalleryShowing = true
+                            }
+                    )
+                }
+                Spacer(modifier = Modifier.padding(vertical = 16.dp))
+                TypingTextField(
+                    text = newNickname,
+                    onValueChange = { newNickname = it },
+                    hintText = "닉네임을 입력하세요",
+                    maxLines = 1,
+                    maxTextLength = 50,
+                    keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
+                    modifier = Modifier
+                        .padding(horizontal = Space20)
+                        .focusRequester(focusRequester)
+                )
+            }
+        }
+        Box(
+            modifier = Modifier
+                .padding(Space20)
+                .fillMaxWidth()
+                .constrainAs(button) {
+                    bottom.linkTo(parent.bottom)
+                }
+        ) {
+            PostNewProfile(
+                newNickname.isNotEmpty() && newNickname != originalNickname,
+                onClicked = {
+                    if (nicknameValidation()) {
+                        argument.intent(
+                            ChangeProfileIntent.OnChangeNickname(newNickname)
+                        )
+                    }
+                    if (newProfileImage != null) {
+                        argument.intent(
+                            ChangeProfileIntent.OnChangeProfileImage(newProfileImage)
+                        )
+                    }
+                }
+            )
+        }
+    }
+    LaunchedEffectWithLifecycle(event, coroutineContext) {
+        argument.intent(ChangeProfileIntent.RefreshProfile)
+        event.eventObserve { event ->
+            when (event) {
+                is ChangeProfileEvent.SetProfile.Success -> {
+                    isSuccessDialogVisible = true
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun PostNewProfile(
+    isPostAvailable: Boolean,
+    onClicked: () -> Unit
+) {
+    val backgroundColor = if (isPostAvailable) Blue400 else Gray200
+    val buttonText = if (isPostAvailable) "수정" else "수정"
+
+    Row(
+        modifier = Modifier
+            .clip(RoundedCornerShape(8.dp))
+            .background(backgroundColor)
+            .fillMaxWidth()
+            .clickable {
+                onClicked()
+            },
+        horizontalArrangement = Arrangement.Center
+    ) {
+        Text(
+            text = buttonText,
+            modifier = Modifier.padding(8.dp),
+            style = Headline2,
+            color = Color.White
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun ChangeProfileScreenPreview() {
+    ChangeProfileScreen(
+        navController = rememberNavController(),
+        argument = ChangeProfileArgument(
+            state = ChangeProfileState.Init,
+            event = MutableEventFlow(),
+            intent = {},
+            logEvent = { _, _ -> },
+            coroutineContext = Dispatchers.IO
+        ),
+        data = ChangeProfileData(
+            myProfile = MyProfile(
+                id = -1,
+                campusId = -1,
+                loginEmail = "",
+                schoolEmail = "",
+                nickname = "User_Nickname",
+                profileImage = "",
+                rating = 10.0
+            )
+        )
+    )
+}

--- a/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/mypage/change_profile/ChangeProfileScreen.kt
+++ b/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/mypage/change_profile/ChangeProfileScreen.kt
@@ -81,19 +81,22 @@ fun ChangeProfileScreen(
     val originalProfileImage = data.myProfile.profileImage
     val originalNickname = data.myProfile.nickname
     var newProfileImage: GalleryImage? by rememberSaveable { mutableStateOf(null) }
-    var newNickname = data.myProfile.nickname
-
-    val isNicknameSizeValid = newNickname.toByteArray(Charsets.UTF_8).size in 0..20
-    val isNicknameFormValid = newNickname.matches("[a-zA-Zㄱ-ㅎㅏ-ㅣ가-힣0-9]*".toRegex())
+    var newNickname: String? by remember { mutableStateOf(null) }
 
     var isSuccessDialogVisible by remember { mutableStateOf(false) }
     var isGalleryShowing by remember { mutableStateOf(false) }
 
     fun nicknameValidation(): Boolean {
-        return newNickname.isNotBlank()
-                && isNicknameSizeValid
-                && isNicknameFormValid
-                && (newNickname != originalNickname)
+        val changedNickname = newNickname
+        if (changedNickname != null) {
+            val isNicknameSizeValid = changedNickname.toByteArray(Charsets.UTF_8).size in 0..20
+            val isNicknameFormValid = changedNickname.matches("[a-zA-Zㄱ-ㅎㅏ-ㅣ가-힣0-9]*".toRegex())
+
+            return isNicknameSizeValid
+                    && isNicknameFormValid
+                    && (changedNickname != originalNickname)
+        }
+        return false
     }
 
     if (isSuccessDialogVisible) {
@@ -192,7 +195,7 @@ fun ChangeProfileScreen(
                 }
                 Spacer(modifier = Modifier.padding(vertical = 16.dp))
                 TypingTextField(
-                    text = newNickname,
+                    text = newNickname ?: originalNickname,
                     onValueChange = { newNickname = it },
                     hintText = "닉네임을 입력하세요",
                     maxLines = 1,
@@ -212,12 +215,14 @@ fun ChangeProfileScreen(
                     bottom.linkTo(parent.bottom)
                 }
         ) {
+            val nickname : String = newNickname ?: ""
+
             PostNewProfile(
-                newNickname.isNotEmpty() && newNickname != originalNickname,
+                nickname.isNotEmpty() && newNickname != originalNickname,
                 onClicked = {
                     if (nicknameValidation()) {
                         argument.intent(
-                            ChangeProfileIntent.OnChangeNickname(newNickname)
+                            ChangeProfileIntent.OnChangeNickname(nickname)
                         )
                     }
                     if (newProfileImage != null) {

--- a/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/mypage/change_profile/ChangeProfileViewModel.kt
+++ b/presentation/src/main/kotlin/kr/linkerbell/campusmarket/android/presentation/ui/main/home/mypage/change_profile/ChangeProfileViewModel.kt
@@ -1,0 +1,161 @@
+package kr.linkerbell.campusmarket.android.presentation.ui.main.home.mypage.change_profile
+
+import androidx.lifecycle.SavedStateHandle
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kr.linkerbell.campusmarket.android.common.util.coroutine.event.EventFlow
+import kr.linkerbell.campusmarket.android.common.util.coroutine.event.MutableEventFlow
+import kr.linkerbell.campusmarket.android.common.util.coroutine.event.asEventFlow
+import kr.linkerbell.campusmarket.android.domain.model.nonfeature.error.ServerException
+import kr.linkerbell.campusmarket.android.domain.model.nonfeature.user.MyProfile
+import kr.linkerbell.campusmarket.android.domain.usecase.nonfeature.file.GetPreSignedUrlUseCase
+import kr.linkerbell.campusmarket.android.domain.usecase.nonfeature.file.UploadImageUseCase
+import kr.linkerbell.campusmarket.android.domain.usecase.nonfeature.user.GetMyProfileUseCase
+import kr.linkerbell.campusmarket.android.domain.usecase.nonfeature.user.SetMyProfileUseCase
+import kr.linkerbell.campusmarket.android.presentation.common.base.BaseViewModel
+import kr.linkerbell.campusmarket.android.presentation.common.base.ErrorEvent
+import kr.linkerbell.campusmarket.android.presentation.model.gallery.GalleryImage
+
+@HiltViewModel
+class ChangeProfileViewModel @Inject constructor(
+    private val savedStateHandle: SavedStateHandle,
+    private val getMyProfileUseCase: GetMyProfileUseCase,
+    private val getPreSignedUrlUseCase: GetPreSignedUrlUseCase,
+    private val uploadImageUseCase: UploadImageUseCase,
+    private val setMyProfileUseCase: SetMyProfileUseCase
+) : BaseViewModel() {
+
+    private val _state: MutableStateFlow<ChangeProfileState> =
+        MutableStateFlow(ChangeProfileState.Init)
+    val state: StateFlow<ChangeProfileState> = _state.asStateFlow()
+
+    private val _event: MutableEventFlow<ChangeProfileEvent> = MutableEventFlow()
+    val event: EventFlow<ChangeProfileEvent> = _event.asEventFlow()
+
+    private val _myProfile: MutableStateFlow<MyProfile> = MutableStateFlow(MyProfile.empty)
+    val myProfile: StateFlow<MyProfile> = _myProfile.asStateFlow()
+
+    fun onIntent(intent: ChangeProfileIntent) {
+        when (intent) {
+            is ChangeProfileIntent.OnChangeNickname -> {
+                launch {
+                    setNickname(nickname = intent.nickname)
+                }
+            }
+
+            is ChangeProfileIntent.OnChangeProfileImage -> {
+                launch {
+                    setProfileImage(image = intent.image)
+                }
+            }
+
+            is ChangeProfileIntent.RefreshProfile -> {
+                launch {
+                    getMyProfile()
+                }
+            }
+        }
+    }
+
+    init {
+        launch {
+            getMyProfile()
+        }
+    }
+
+    private suspend fun setNickname(nickname: String) {
+        setMyProfileUseCase(
+            nickname = nickname,
+            profileImage = _myProfile.value.profileImage
+        ).onSuccess {
+            _state.value = ChangeProfileState.Init
+            _event.emit(ChangeProfileEvent.SetProfile.Success)
+        }.onFailure { exception ->
+            _state.value = ChangeProfileState.Init
+            when (exception) {
+                is ServerException -> {
+                    _errorEvent.emit(ErrorEvent.InvalidRequest(exception))
+                }
+
+                else -> {
+                    _errorEvent.emit(ErrorEvent.UnavailableServer(exception))
+                }
+            }
+            _myProfile.value = MyProfile.empty
+        }
+    }
+
+    private suspend fun setProfileImage(image: GalleryImage?) {
+        if (image == null) {
+            setMyProfileUseCase(
+                nickname = _myProfile.value.nickname,
+                profileImage = ""
+            ).onSuccess {
+                _state.value = ChangeProfileState.Init
+                _event.emit(ChangeProfileEvent.SetProfile.Success)
+            }.onFailure { exception ->
+                _state.value = ChangeProfileState.Init
+                when (exception) {
+                    is ServerException -> {
+                        _errorEvent.emit(ErrorEvent.InvalidRequest(exception))
+                    }
+
+                    else -> {
+                        _errorEvent.emit(ErrorEvent.UnavailableServer(exception))
+                    }
+                }
+            }
+        } else {
+            getPreSignedUrlUseCase(
+                fileName = image.name
+            ).map { preSignedUrl ->
+                uploadImageUseCase(
+                    preSignedUrl = preSignedUrl.preSignedUrl,
+                    imageUri = image.filePath
+                ).map {
+                    setMyProfileUseCase(
+                        nickname = _myProfile.value.nickname,
+                        profileImage = preSignedUrl.s3url
+                    )
+                }
+            }.onSuccess {
+                _state.value = ChangeProfileState.Init
+                _event.emit(ChangeProfileEvent.SetProfile.Success)
+            }.onFailure { exception ->
+                _state.value = ChangeProfileState.Init
+                when (exception) {
+                    is ServerException -> {
+                        _errorEvent.emit(ErrorEvent.InvalidRequest(exception))
+                    }
+
+                    else -> {
+                        _errorEvent.emit(ErrorEvent.UnavailableServer(exception))
+                    }
+                }
+            }
+            _state.value = ChangeProfileState.Loading
+        }
+    }
+
+    private suspend fun getMyProfile() {
+        getMyProfileUseCase().onSuccess {
+            _state.value = ChangeProfileState.Init
+            _myProfile.value = it
+        }.onFailure { exception ->
+            _state.value = ChangeProfileState.Init
+            when (exception) {
+                is ServerException -> {
+                    _errorEvent.emit(ErrorEvent.InvalidRequest(exception))
+                }
+
+                else -> {
+                    _errorEvent.emit(ErrorEvent.UnavailableServer(exception))
+                }
+            }
+            _myProfile.value = MyProfile.empty
+        }
+    }
+}


### PR DESCRIPTION
## **설명**
- [CM-31.1] 사용자 프로필 수정 페이지 UI & 로직 제작

## 참고
- 회원가입에 있던 화면 상당 부분 재활용함
- 
![image](https://github.com/user-attachments/assets/2a1302e7-aef7-4733-95fd-09103713ed40)
수정하면
![image](https://github.com/user-attachments/assets/1c09558c-0ca2-442c-8311-9baa5312376d)
이렇게 바뀜

## 체크리스트
- [x] : 빌드 테스트를 진행하셨나요?
- [x] : 실제 기기에서 테스트를 진행하셨나요?
